### PR TITLE
patch0: Avoid multiple definitions of the verbose variable

### DIFF
--- a/patches/patch0.txt
+++ b/patches/patch0.txt
@@ -1,6 +1,6 @@
-diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patched/compressor.c
---- squashfs-tools/compressor.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.c	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patched/compressor.c
+--- squashfs-tools/compressor.c	2014-03-09 07:31:58.000000000 +0200
++++ squashfs-tools-patched/compressor.c	2022-09-05 23:51:29.913461044 +0300
 @@ -25,6 +25,9 @@
  #include "compressor.h"
  #include "squashfs_fs.h"
@@ -120,9 +120,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patc
 +    return retval;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patched/compressor.h
---- squashfs-tools/compressor.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.h	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patched/compressor.h
+--- squashfs-tools/compressor.h	2014-05-10 07:54:13.000000000 +0300
++++ squashfs-tools-patched/compressor.h	2022-09-05 23:51:29.913461044 +0300
 @@ -59,11 +59,14 @@
  }
  
@@ -138,16 +138,16 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patc
  
  
  /*
-diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
---- squashfs-tools/error.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/error.h	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
+--- squashfs-tools/error.h	2014-05-10 07:54:13.000000000 +0300
++++ squashfs-tools-patched/error.h	2022-09-05 23:52:22.831169685 +0300
 @@ -30,14 +30,18 @@
  extern void progressbar_error(char *fmt, ...);
  extern void progressbar_info(char *fmt, ...);
  
 -#ifdef SQUASHFS_TRACE
-+// CJH: Updated so that TRACE prints if -verbose is specified on the command line
-+int verbose;
++
++extern int verbose;
 +//#ifdef SQUASHFS_TRACE
  #define TRACE(s, args...) \
  		do { \
@@ -162,9 +162,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/e
  
  #define INFO(s, args...) \
  		do {\
-diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/LICENSE
---- squashfs-tools/LICENSE	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LICENSE	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/LICENSE
+--- squashfs-tools/LICENSE	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LICENSE	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,339 @@
 +                    GNU GENERAL PUBLIC LICENSE
 +                       Version 2, June 1991
@@ -505,9 +505,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/L
 +consider it more useful to permit linking proprietary applications with the
 +library.  If this is what you want to do, use the GNU Lesser General
 +Public License instead of this License.
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-tools-patched/LZMA/lzma465/7zC.txt
---- squashfs-tools/LZMA/lzma465/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-tools-patched/LZMA/lzma465/7zC.txt
+--- squashfs-tools/LZMA/lzma465/7zC.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,194 @@
 +7z ANSI-C Decoder 4.62
 +----------------------
@@ -703,9 +703,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-to
 +http://www.7-zip.org
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squashfs-tools-patched/LZMA/lzma465/7zFormat.txt
---- squashfs-tools/LZMA/lzma465/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squashfs-tools-patched/LZMA/lzma465/7zFormat.txt
+--- squashfs-tools/LZMA/lzma465/7zFormat.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -1178,9 +1178,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squash
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c
+--- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,45 @@
 +/* 7zBuf2.c -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1227,9 +1227,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs
 +  p->size = 0;
 +  p->pos = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c
+--- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,36 @@
 +/* 7zBuf.c -- Byte Buffer
 +2008-03-28
@@ -1267,9 +1267,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-
 +  p->data = 0;
 +  p->size = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h
---- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h
+--- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,31 @@
 +/* 7zBuf.h -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1302,9 +1302,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-
 +void DynBuf_Free(CDynBuf *p, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c
---- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c
+--- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,35 @@
 +/* 7zCrc.c -- CRC32 calculation
 +2008-08-05
@@ -1341,9 +1341,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-
 +{
 +  return CrcUpdate(CRC_INIT_VAL, data, size) ^ 0xFFFFFFFF;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h
---- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h
+--- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h -- CRC32 calculation
 +2008-03-13
@@ -1369,9 +1369,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-
 +UInt32 MY_FAST_CALL CrcCalc(const void *data, size_t size);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs-tools-patched/LZMA/lzma465/C/7zFile.c
---- squashfs-tools/LZMA/lzma465/C/7zFile.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs-tools-patched/LZMA/lzma465/C/7zFile.c
+--- squashfs-tools/LZMA/lzma465/C/7zFile.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,263 @@
 +/* 7zFile.c -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1636,9 +1636,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs
 +{
 +  p->s.Write = FileOutStream_Write;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs-tools-patched/LZMA/lzma465/C/7zFile.h
---- squashfs-tools/LZMA/lzma465/C/7zFile.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs-tools-patched/LZMA/lzma465/C/7zFile.h
+--- squashfs-tools/LZMA/lzma465/C/7zFile.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,74 @@
 +/* 7zFile.h -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1714,9 +1714,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs
 +void FileOutStream_CreateVTable(CFileOutStream *p);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squashfs-tools-patched/LZMA/lzma465/C/7zStream.c
---- squashfs-tools/LZMA/lzma465/C/7zStream.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squashfs-tools-patched/LZMA/lzma465/C/7zStream.c
+--- squashfs-tools/LZMA/lzma465/C/7zStream.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,169 @@
 +/* 7zStream.c -- 7z Stream functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -1887,9 +1887,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squash
 +{
 +  p->s.Read = SecToRead_Read;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h
---- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h
+--- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,7 @@
 +#define MY_VER_MAJOR 4
 +#define MY_VER_MINOR 65
@@ -1898,9 +1898,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squas
 +#define MY_DATE "2009-02-03"
 +#define MY_COPYRIGHT ": Igor Pavlov : Public domain"
 +#define MY_VERSION_COPYRIGHT_DATE MY_VERSION " " MY_COPYRIGHT " : " MY_DATE
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-tools-patched/LZMA/lzma465/C/Alloc.c
---- squashfs-tools/LZMA/lzma465/C/Alloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-tools-patched/LZMA/lzma465/C/Alloc.c
+--- squashfs-tools/LZMA/lzma465/C/Alloc.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,127 @@
 +/* Alloc.c -- Memory allocation functions
 +2008-09-24
@@ -2029,9 +2029,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-tools-patched/LZMA/lzma465/C/Alloc.h
---- squashfs-tools/LZMA/lzma465/C/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-tools-patched/LZMA/lzma465/C/Alloc.h
+--- squashfs-tools/LZMA/lzma465/C/Alloc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,32 @@
 +/* Alloc.h -- Memory allocation functions
 +2008-03-13
@@ -2065,9 +2065,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,77 @@
 +/* 7zAlloc.c -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2146,9 +2146,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +  #endif
 +  free(address);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,15 @@
 +/* 7zAlloc.h -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2165,9 +2165,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +void SzFreeTemp(void *p, void *address);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,254 @@
 +/* 7zDecode.c -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2423,9 +2423,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +    IAlloc_Free(allocMain, tempBuf[i]);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,13 @@
 +/* 7zDecode.h -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2440,9 +2440,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +    Byte *outBuffer, size_t outSize, ISzAlloc *allocMain);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,199 @@
 +# Microsoft Developer Studio Project File - Name="7z" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -2643,9 +2643,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2022-09-05 23:51:29.917461173 +0300
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -2676,9 +2676,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,93 @@
 +/* 7zExtract.c -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2773,9 +2773,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +  }
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,41 @@
 +/* 7zExtract.h -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2818,9 +2818,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +    ISzAlloc *allocTemp);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,6 @@
 +/*  7zHeader.c -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2828,9 +2828,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +#include "7zHeader.h"
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,57 @@
 +/* 7zHeader.h -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2889,9 +2889,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,1204 @@
 +/* 7zIn.c -- 7z Input functions
 +2008-12-31 : Igor Pavlov : Public domain */
@@ -4097,9 +4097,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c
 +    SzArEx_Free(p, allocMain);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,41 @@
 +/* 7zIn.h -- 7z Input functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4142,9 +4142,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h
 +SRes SzArEx_Open(CSzArEx *p, ILookInStream *inStream, ISzAlloc *allocMain, ISzAlloc *allocTemp);
 + 
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,127 @@
 +/* 7zItem.c -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4273,9 +4273,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +  IAlloc_Free(alloc, p->Files);
 +  SzAr_Init(p);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,84 @@
 +/* 7zItem.h -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4361,9 +4361,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +void SzAr_Free(CSzAr *p, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,262 @@
 +/* 7zMain.c - Test application for 7z Decoder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4627,9 +4627,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain
 +    printf("\nERROR #%d\n", res);
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,33 @@
 +MY_STATIC_LINK=1
 +
@@ -4664,9 +4664,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +	$(COMPL_O1)
 +$(C_OBJS): ../../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,61 @@
 +PROG = 7zDec
 +CXX = g++
@@ -4729,9 +4729,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c
---- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c
+--- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,132 @@
 +/* Bcj2.c -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4865,9 +4865,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-t
 +  }
 +  return (outPos == outSize) ? SZ_OK : SZ_ERROR_DATA;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h
---- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h
+--- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,30 @@
 +/* Bcj2.h -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4899,9 +4899,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-t
 +    Byte *outBuf, SizeT outSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-tools-patched/LZMA/lzma465/C/Bra86.c
---- squashfs-tools/LZMA/lzma465/C/Bra86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-tools-patched/LZMA/lzma465/C/Bra86.c
+--- squashfs-tools/LZMA/lzma465/C/Bra86.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,85 @@
 +/* Bra86.c -- Converter for x86 code (BCJ)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4988,9 +4988,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-
 +  *state = ((prevPosT > 3) ? 0 : ((prevMask << ((int)prevPosT - 1)) & 0x7));
 +  return bufferPos;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-tools-patched/LZMA/lzma465/C/Bra.c
---- squashfs-tools/LZMA/lzma465/C/Bra.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-tools-patched/LZMA/lzma465/C/Bra.c
+--- squashfs-tools/LZMA/lzma465/C/Bra.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,133 @@
 +/* Bra.c -- Converters for RISC code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5125,9 +5125,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-to
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-tools-patched/LZMA/lzma465/C/Bra.h
---- squashfs-tools/LZMA/lzma465/C/Bra.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-tools-patched/LZMA/lzma465/C/Bra.h
+--- squashfs-tools/LZMA/lzma465/C/Bra.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,60 @@
 +/* Bra.h -- Branch converters for executables
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5189,9 +5189,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-to
 +SizeT IA64_Convert(Byte *data, SizeT size, UInt32 ip, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c
---- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c
+--- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,67 @@
 +/* BraIA64.c -- Converter for IA-64 code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5260,9 +5260,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashf
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h
---- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h
+--- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,69 @@
 +/* CpuArch.h
 +2008-08-05
@@ -5333,9 +5333,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashf
 +#define GetBe16(p) (((UInt16)((const Byte *)(p))[0] << 8) | ((const Byte *)(p))[1])
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs-tools-patched/LZMA/lzma465/C/LzFind.c
---- squashfs-tools/LZMA/lzma465/C/LzFind.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs-tools-patched/LZMA/lzma465/C/LzFind.c
+--- squashfs-tools/LZMA/lzma465/C/LzFind.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,751 @@
 +/* LzFind.c -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6088,9 +6088,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs
 +    vTable->Skip = (Mf_Skip_Func)Bt4_MatchFinder_Skip;
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs-tools-patched/LZMA/lzma465/C/LzFind.h
---- squashfs-tools/LZMA/lzma465/C/LzFind.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs-tools-patched/LZMA/lzma465/C/LzFind.h
+--- squashfs-tools/LZMA/lzma465/C/LzFind.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2022-09-05 23:51:29.921461301 +0300
 @@ -0,0 +1,107 @@
 +/* LzFind.h -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6199,9 +6199,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs
 +void Hc3Zip_MatchFinder_Skip(CMatchFinder *p, UInt32 num);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c
+--- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,793 @@
 +/* LzFindMt.c -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6996,9 +6996,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squash
 +    */
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h
+--- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,97 @@
 +/* LzFindMt.h -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7097,9 +7097,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squash
 +void MatchFinderMt_ReleaseStream(CMatchFinderMt *p);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs-tools-patched/LZMA/lzma465/C/LzHash.h
---- squashfs-tools/LZMA/lzma465/C/LzHash.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs-tools-patched/LZMA/lzma465/C/LzHash.h
+--- squashfs-tools/LZMA/lzma465/C/LzHash.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,54 @@
 +/* LzHash.h -- HASH functions for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7155,9 +7155,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs
 +  hash4Value = (temp ^ ((UInt32)cur[2] << 8) ^ (p->crc[cur[3]] << 5)) & (kHash4Size - 1); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,1007 @@
 +/* LzmaDec.c -- LZMA Decoder
 +2008-11-06 : Igor Pavlov : Public domain */
@@ -8166,9 +8166,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashf
 +  LzmaDec_FreeProbs(&p, alloc);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,223 @@
 +/* LzmaDec.h -- LZMA Decoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -8393,9 +8393,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashf
 +    ELzmaStatus *status, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,2281 @@
 +/* LzmaEnc.c -- LZMA Encoder
 +2009-02-02 : Igor Pavlov : Public domain */
@@ -10678,9 +10678,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashf
 +  LzmaEnc_Destroy(p, alloc, allocBig);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,72 @@
 +/*  LzmaEnc.h -- LZMA Encoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10754,17 +10754,17 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashf
 +    ICompressProgress *progress, ISzAlloc *alloc, ISzAlloc *allocBig);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,4 @@
 +EXPORTS
 +  LzmaCompress
 +  LzmaUncompress
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="LzmaLib" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -10944,9 +10944,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -10977,9 +10977,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,12 @@
 +/* LzmaLibExports.c -- LZMA library DLL Entry point
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10993,9 +10993,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibEx
 +  lpReserved = lpReserved;
 +  return TRUE;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,37 @@
 +MY_STATIC_LINK=1
 +SLIB = sLZMA.lib
@@ -11034,17 +11034,17 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile 
 +	$(COMPL_O2)
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,4 @@
 +#include "../../CPP/7zip/MyVersionInfo.rc"
 +
 +MY_VERSION_INFO_DLL("LZMA library", "LZMA")
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,46 @@
 +/* LzmaLib.c -- LZMA library wrapper
 +2008-08-05
@@ -11092,9 +11092,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashf
 +  ELzmaStatus status;
 +  return LzmaDecode(dest, destLen, src, srcLen, props, (unsigned)propsSize, LZMA_FINISH_ANY, &status, &g_Alloc);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,135 @@
 +/* LzmaLib.h -- LZMA library interface
 +2008-08-05
@@ -11231,9 +11231,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashf
 +  const unsigned char *props, size_t propsSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,61 @@
 +/* Lzma86Dec.c -- LZMA + x86 (BCJ) Filter Decoder
 +2008-04-07
@@ -11296,9 +11296,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +  }
 +  return SZ_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,45 @@
 +/* Lzma86Dec.h -- LZMA + x86 (BCJ) Filter Decoder
 +2008-08-05
@@ -11345,9 +11345,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +SRes Lzma86_Decode(Byte *dest, SizeT *destLen, const Byte *src, SizeT *srcLen);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,113 @@
 +/* Lzma86Enc.c -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11462,9 +11462,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +    MyFree(filteredStream);
 +  return mainResult;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,72 @@
 +/* Lzma86Enc.h -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11538,9 +11538,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +    int level, UInt32 dictSize, int filterMode);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,254 @@
 +/* LzmaUtil.c -- Test application for LZMA compression
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -11796,9 +11796,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,168 @@
 +# Microsoft Developer Studio Project File - Name="LzmaUtil" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -11968,9 +11968,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -12001,9 +12001,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,29 @@
 +MY_STATIC_LINK=1
 +PROG = LZMAc.exe
@@ -12034,9 +12034,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +	$(COMPL_O2)
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,44 @@
 +PROG = lzma
 +CXX = g++
@@ -12082,9 +12082,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashfs-tools-patched/LZMA/lzma465/C/Threads.c
---- squashfs-tools/LZMA/lzma465/C/Threads.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashfs-tools-patched/LZMA/lzma465/C/Threads.c
+--- squashfs-tools/LZMA/lzma465/C/Threads.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,109 @@
 +/* Threads.c -- multithreading library
 +2008-08-05
@@ -12195,9 +12195,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashf
 +  return 0;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashfs-tools-patched/LZMA/lzma465/C/Threads.h
---- squashfs-tools/LZMA/lzma465/C/Threads.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashfs-tools-patched/LZMA/lzma465/C/Threads.h
+--- squashfs-tools/LZMA/lzma465/C/Threads.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,68 @@
 +/* Threads.h -- multithreading library
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -12267,9 +12267,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashf
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-tools-patched/LZMA/lzma465/C/Types.h
---- squashfs-tools/LZMA/lzma465/C/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-tools-patched/LZMA/lzma465/C/Types.h
+--- squashfs-tools/LZMA/lzma465/C/Types.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,208 @@
 +/* Types.h -- Basic types
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -12479,9 +12479,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-
 +#define IAlloc_Free(p, a) (p)->Free((p), a)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashfs-tools-patched/LZMA/lzma465/history.txt
---- squashfs-tools/LZMA/lzma465/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/history.txt	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashfs-tools-patched/LZMA/lzma465/history.txt
+--- squashfs-tools/LZMA/lzma465/history.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/history.txt	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,236 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -12719,9 +12719,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashf
 +  
 +
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-tools-patched/LZMA/lzma465/lzma.txt
---- squashfs-tools/LZMA/lzma465/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-tools-patched/LZMA/lzma465/lzma.txt
+--- squashfs-tools/LZMA/lzma465/lzma.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,594 @@
 +LZMA SDK 4.65
 +-------------
@@ -13317,9 +13317,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-t
 +http://www.7-zip.org
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashfs-tools-patched/LZMA/lzma465/Methods.txt
---- squashfs-tools/LZMA/lzma465/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashfs-tools-patched/LZMA/lzma465/Methods.txt
+--- squashfs-tools/LZMA/lzma465/Methods.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,137 @@
 +7-Zip method IDs (4.65)
 +-----------------------
@@ -13458,9 +13458,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashf
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt
---- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt
+--- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,235 @@
 +7z ANSI-C Decoder 4.23
 +----------------------
@@ -13697,9 +13697,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashf
 +
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt
---- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt
+--- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -14172,9 +14172,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt sq
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,70 @@
 +/* 7zAlloc.c */
 +
@@ -14246,9 +14246,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  #endif
 +  free(address);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,20 @@
 +/* 7zAlloc.h */
 +
@@ -14270,9 +14270,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +void SzFreeTemp(void *address);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,29 @@
 +/* 7zBuffer.c */
 +
@@ -14303,9 +14303,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  buffer->Items = 0;
 +  buffer->Capacity = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,19 @@
 +/* 7zBuffer.h */
 +
@@ -14326,9 +14326,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +void SzByteBufferFree(CSzByteBuffer *buffer, void (*freeFunc)(void *));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="7z_C" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -14508,9 +14508,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -14541,9 +14541,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,76 @@
 +/* 7zCrc.c */
 +
@@ -14621,9 +14621,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +{
 +  return (CrcCalculateDigest(data, size) == digest);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h */
 +
@@ -14649,9 +14649,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +int CrcVerifyDigest(UInt32 digest, const void *data, size_t size);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,150 @@
 +/* 7zDecode.c */
 +
@@ -14803,9 +14803,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  }
 +  return SZE_NOTIMPL;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,21 @@
 +/* 7zDecode.h */
 +
@@ -14828,9 +14828,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    size_t *outSizeProcessed, ISzAlloc *allocMain);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,116 @@
 +/* 7zExtract.c */
 +
@@ -14948,9 +14948,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  }
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,40 @@
 +/* 7zExtract.h */
 +
@@ -14992,18 +14992,18 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    ISzAlloc *allocTemp);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,5 @@
 +/*  7zHeader.c */
 +
 +#include "7zHeader.h"
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,55 @@
 +/* 7zHeader.h */
 +
@@ -15060,9 +15060,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,1292 @@
 +/* 7zIn.c */
 +
@@ -16356,9 +16356,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    SzArDbExFree(db, allocMain->Free);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,55 @@
 +/* 7zIn.h */
 +
@@ -16415,9 +16415,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    ISzAlloc *allocTemp);
 + 
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,133 @@
 +/* 7zItem.c */
 +
@@ -16552,9 +16552,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  freeFunc(db->Files);
 +  SzArchiveDatabaseInit(db);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,90 @@
 +/* 7zItem.h */
 +
@@ -16646,9 +16646,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,223 @@
 +/* 
 +7zMain.c
@@ -16873,9 +16873,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    printf("\nERROR #%d\n", res);
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,14 @@
 +/* 7zMethodID.c */
 +
@@ -16891,9 +16891,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +      return 0;
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,18 @@
 +/* 7zMethodID.h */
 +
@@ -16913,9 +16913,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +int AreMethodsEqual(CMethodID *a1, CMethodID *a2);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,61 @@
 +/* 7zTypes.h */
 +
@@ -16978,9 +16978,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#define RINOK(x) { int __result_ = (x); if(__result_ != 0) return __result_; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,55 @@
 +PROG = 7zDec.exe
 +
@@ -17037,9 +17037,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +	$(COMPL)
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2022-09-05 23:51:29.925461430 +0300
 @@ -0,0 +1,50 @@
 +PROG = 7zDec
 +CXX = g++
@@ -17091,9 +17091,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,251 @@
 +// FileStreams.cpp
 +
@@ -17346,9 +17346,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +}
 +  
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,98 @@
 +// FileStreams.h
 +
@@ -17448,9 +17448,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,80 @@
 +// InBuffer.cpp
 +
@@ -17532,9 +17532,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +    return 0xFF;
 +  return *_buffer++;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,76 @@
 +// InBuffer.h
 +
@@ -17612,9 +17612,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,117 @@
 +// OutByte.cpp
 +
@@ -17733,9 +17733,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +    throw COutBufferException(result);
 +  #endif
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,64 @@
 +// OutBuffer.h
 +
@@ -17801,9 +17801,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -17814,9 +17814,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +#include "../../Common/NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,44 @@
 +// StreamUtils.cpp
 +
@@ -17862,9 +17862,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +  }
 +  return S_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,11 @@
 +// StreamUtils.h
 +
@@ -17877,9 +17877,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +HRESULT WriteStream(ISequentialOutStream *stream, const void *data, UInt32 size, UInt32 *processedSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,16 @@
 +// ARM.cpp
 +
@@ -17897,9 +17897,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::ARM_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// ARM.h
 +
@@ -17911,9 +17911,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_ARM, 0x05, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,16 @@
 +// ARMThumb.cpp
 +
@@ -17931,9 +17931,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::ARMThumb_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// ARMThumb.h
 +
@@ -17945,9 +17945,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_ARMThumb, 0x07, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,26 @@
 +// BranchARM.c
 +
@@ -17975,9 +17975,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// BranchARM.h
 +
@@ -17989,9 +17989,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 ARM_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,35 @@
 +// BranchARMThumb.c
 +
@@ -18028,9 +18028,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// BranchARMThumb.h
 +
@@ -18042,9 +18042,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 ARMThumb_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,18 @@
 +// BranchCoder.cpp
 +
@@ -18064,9 +18064,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  _bufferPos += processedSize;
 +  return processedSize;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,54 @@
 +// BranchCoder.h
 +
@@ -18122,9 +18122,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassDecoderB(Name ## _Decoder, ADD_ITEMS, ADD_INIT)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,65 @@
 +// BranchIA64.c
 +
@@ -18191,9 +18191,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// BranchIA64.h
 +
@@ -18205,9 +18205,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 IA64_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,36 @@
 +// BranchPPC.c
 +
@@ -18245,9 +18245,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// BranchPPC.h
 +
@@ -18259,9 +18259,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 PPC_B_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,36 @@
 +// BranchSPARC.c
 +
@@ -18299,9 +18299,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// BranchSPARC.h
 +
@@ -18313,9 +18313,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 SPARC_B_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,101 @@
 +/* BranchX86.c */
 +
@@ -18418,9 +18418,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return bufferPos;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,19 @@
 +/* BranchX86.h */
 +
@@ -18441,9 +18441,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    UInt32 *prevMask, UInt32 *prevPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,16 @@
 +// IA64.cpp
 +
@@ -18461,9 +18461,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::IA64_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// IA64.h
 +
@@ -18475,9 +18475,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_IA64, 0x04, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,17 @@
 +// PPC.cpp
 +
@@ -18496,9 +18496,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::PPC_B_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// PPC.h
 +
@@ -18510,9 +18510,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_PPC_B, 0x02, 5)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,17 @@
 +// SPARC.cpp
 +
@@ -18531,9 +18531,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::SPARC_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,10 @@
 +// SPARC.h
 +
@@ -18545,9 +18545,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_SPARC, 0x08, 5)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -18557,9 +18557,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,412 @@
 +// x86_2.cpp
 +
@@ -18973,9 +18973,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  catch(const COutBufferException &e) { return e.ErrorCode; }
 +  catch(...) { return S_FALSE; }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,133 @@
 +// x86_2.h
 +
@@ -19110,9 +19110,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}; 
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,18 @@
 +// x86.cpp
 +
@@ -19132,9 +19132,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::x86_Convert(data, size, _bufferPos, &_prevMask, &_prevPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,19 @@
 +// x86.h
 +
@@ -19155,9 +19155,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    virtual void SubInit() { x86Init(); })
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,12 @@
 +// BinTree2.h
 +
@@ -19171,9 +19171,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "BinTreeMain.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,16 @@
 +// BinTree3.h
 +
@@ -19191,9 +19191,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_ARRAY_2
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,16 @@
 +// BinTree3Z.h
 +
@@ -19211,9 +19211,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_ZIP
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,20 @@
 +// BinTree4b.h
 +
@@ -19235,9 +19235,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_BIG
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,18 @@
 +// BinTree4.h
 +
@@ -19257,9 +19257,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_ARRAY_3
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,55 @@
 +// BinTree.h
 +
@@ -19316,9 +19316,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,444 @@
 +// BinTreeMain.h
 +
@@ -19764,9 +19764,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 + 
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,13 @@
 +// HC2.h
 +
@@ -19781,9 +19781,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,17 @@
 +// HC3.h
 +
@@ -19802,9 +19802,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,21 @@
 +// HC4b.h
 +
@@ -19827,9 +19827,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,19 @@
 +// HC4.h
 +
@@ -19850,9 +19850,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,55 @@
 +// HC.h
 +
@@ -19909,9 +19909,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,350 @@
 +// HC.h
 +
@@ -20263,9 +20263,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 + 
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,63 @@
 +// MatchFinders/IMatchFinder.h
 +
@@ -20330,9 +20330,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +*/
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,102 @@
 +// LZInWindow.cpp
 +
@@ -20436,9 +20436,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  _buffer -= offset;
 +  AfterMoveBlock();
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,84 @@
 +// LZInWindow.h
 +
@@ -20524,9 +20524,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,17 @@
 +// LZOutWindow.cpp
 +
@@ -20545,9 +20545,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,64 @@
 +// LZOutWindow.h
 +
@@ -20613,9 +20613,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,22 @@
 +// Pat2.h
 +
@@ -20639,9 +20639,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,24 @@
 +// Pat2H.h
 +
@@ -20667,9 +20667,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,20 @@
 +// Pat2R.h
 +
@@ -20691,9 +20691,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,24 @@
 +// Pat3H.h
 +
@@ -20719,9 +20719,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,24 @@
 +// Pat4H.h
 +
@@ -20747,9 +20747,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,318 @@
 +// Pat.h
 +
@@ -21069,9 +21069,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +// #endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,989 @@
 +// PatMain.h
 +
@@ -22062,9 +22062,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -22072,9 +22072,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define __STDAFX_H
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2022-09-05 23:51:29.929461560 +0300
 @@ -0,0 +1,342 @@
 +// LZMADecoder.cpp
 +
@@ -22418,9 +22418,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,249 @@
 +// LZMA/Decoder.h
 +
@@ -22671,9 +22671,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,1504 @@
 +// LZMA/Encoder.cpp
 +
@@ -24179,9 +24179,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,416 @@
 +// LZMA/Encoder.h
 +
@@ -24599,9 +24599,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,82 @@
 +// LZMA.h
 +
@@ -24685,9 +24685,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -24697,9 +24697,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,523 @@
 +# Microsoft Developer Studio Project File - Name="AloneLZMA" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -25224,9 +25224,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -25257,9 +25257,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,509 @@
 +// LzmaAlone.cpp
 +
@@ -25770,9 +25770,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    return 1; 
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,508 @@
 +// LzmaBench.cpp
 +
@@ -26282,9 +26282,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  fprintf(f, "    Average\n");
 +  return 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,11 @@
 +// LzmaBench.h
 +
@@ -26297,9 +26297,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +int LzmaBenchmark(FILE *f, UInt32 numIterations, UInt32 dictionarySize, bool isBT4);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,228 @@
 +// LzmaRam.cpp
 +
@@ -26529,9 +26529,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  } catch(...) { return SZE_OUTOFMEMORY; }
 +  #endif
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,79 @@
 +/* LzmaRamDecode.c */
 +
@@ -26612,9 +26612,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,55 @@
 +/* LzmaRamDecode.h */
 +
@@ -26671,9 +26671,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    void (*freeFunc)(void *));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,46 @@
 +// LzmaRam.h
 +
@@ -26721,9 +26721,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    UInt32 dictionarySize, ESzFilterMode filterMode);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,100 @@
 +PROG = lzma.exe
 +CFLAGS = $(CFLAGS) -I ../../../
@@ -26825,9 +26825,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL)
 +$O\FileIO.obj: ../../../Windows/FileIO.cpp
 +	$(COMPL)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,113 @@
 +PROG = lzma
 +CXX = g++ -O2 -Wall
@@ -26942,16 +26942,16 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,3 @@
 +// StdAfx.cpp
 +
 +#include "StdAfx.h"
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -26961,9 +26961,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,588 @@
 +/*
 +  LzmaDecode.c
@@ -27553,9 +27553,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  *outSizeProcessed = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,131 @@
 +/* 
 +  LzmaDecode.h
@@ -27688,9 +27688,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    unsigned char *outStream, SizeT outSize, SizeT *outSizeProcessed);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,716 @@
 +/*
 +  LzmaDecodeSize.c
@@ -28408,9 +28408,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  *outSizeProcessed = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,521 @@
 +/*
 +  LzmaStateDecode.c
@@ -28933,9 +28933,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  (*outSizeProcessed) = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,115 @@
 +/* 
 +  LzmaStateDecode.h
@@ -29052,9 +29052,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    int finishDecoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,195 @@
 +/* 
 +LzmaStateTest.c
@@ -29251,9 +29251,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,342 @@
 +/* 
 +LzmaTest.c
@@ -29597,9 +29597,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,43 @@
 +PROG = lzmaDec.exe
 +
@@ -29644,9 +29644,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL)
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,23 @@
 +PROG = lzmadec
 +CXX = gcc 
@@ -29671,9 +29671,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,21 @@
 +#ifndef __LZMA_LIB_H__
 +#define __LZMA_LIB_H__
@@ -29696,9 +29696,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +int lzmaspec_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int lc, int lp, int pb, int dictionary_size, int offset));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,92 @@
 +PROG = liblzmalib.a
 +CXX = g++ -O3 -Wall
@@ -29792,9 +29792,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,451 @@
 +/*
 + * lzma zlib simplified wrapper
@@ -30247,9 +30247,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	return Z_OK;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,80 @@
 +// Compress/RangeCoder/RangeCoderBit.cpp
 +
@@ -30331,9 +30331,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,120 @@
 +// Compress/RangeCoder/RangeCoderBit.h
 +
@@ -30455,9 +30455,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,161 @@
 +// Compress/RangeCoder/RangeCoderBitTree.h
 +
@@ -30620,9 +30620,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,205 @@
 +// Compress/RangeCoder/RangeCoder.h
 +
@@ -30829,9 +30829,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,31 @@
 +// Compress/RangeCoder/RangeCoderOpt.h
 +
@@ -30864,9 +30864,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define RC_GETBIT(numMoveBits, prob, mi) RC_GETBIT2(numMoveBits, prob, mi, ; , ;)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -30874,9 +30874,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define __STDAFX_H
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,156 @@
 +// ICoder.h
 +
@@ -31034,9 +31034,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2016-08-25 09:06:03.227530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,62 @@
 +// IStream.h
 +
@@ -31100,9 +31100,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,118 @@
 +// Common/Alloc.cpp
 +
@@ -31222,9 +31222,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,29 @@
 +// Common/Alloc.h
 +
@@ -31255,9 +31255,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,78 @@
 +// Common/C_FileIO.h
 +
@@ -31337,9 +31337,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +}
 +
 +}}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,45 @@
 +// Common/C_FileIO.h
 +
@@ -31386,9 +31386,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +}}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,263 @@
 +// CommandLineParser.cpp
 +
@@ -31653,9 +31653,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +}
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,82 @@
 +// Common/CommandLineParser.h
 +
@@ -31739,9 +31739,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,17 @@
 +// ComTry.h
 +
@@ -31760,9 +31760,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry
 +  // catch(...) { return E_FAIL; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,61 @@
 +// Common/CRC.cpp
 +
@@ -31825,9 +31825,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cp
 +    v = Table[((Byte)(v)) ^ *p] ^ (v >> 8);
 +  _value = v;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,36 @@
 +// Common/CRC.h
 +
@@ -31865,9 +31865,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h 
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,20 @@
 +// Common/Defs.h
 +
@@ -31889,9 +31889,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h
 +  { return (value != 0); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,203 @@
 +// MyCom.h
 +
@@ -32096,9 +32096,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.
 +  )
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,54 @@
 +// Common/MyGuidDef.h
 +
@@ -32154,9 +32154,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuid
 +  #define DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
 +    MY_EXTERN_C const GUID name
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,13 @@
 +// Common/MyInitGuid.h
 +
@@ -32171,9 +32171,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInit
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,24 @@
 +// MyUnknown.h
 +
@@ -32199,9 +32199,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnkn
 +#endif
 +  
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,183 @@
 +// MyWindows.h
 +
@@ -32386,9 +32386,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWind
 +
 +#endif
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,114 @@
 +// NewHandler.cpp
 + 
@@ -32504,9 +32504,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +  // _set_new_handler(MemErrorOldVCFunction);
 +}
 +*/
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,14 @@
 +// Common/NewHandler.h
 +
@@ -32522,9 +32522,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +operator delete(void *p) throw();
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -32535,9 +32535,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx
 +#include "NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,93 @@
 +// Common/StringConvert.cpp
 +
@@ -32632,9 +32632,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,71 @@
 +// Common/StringConvert.h
 +
@@ -32707,9 +32707,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,198 @@
 +// Common/String.cpp
 +
@@ -32909,9 +32909,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +  return MyStringCompareNoCase(MultiByteToUnicodeString(s1), MultiByteToUnicodeString(s2));
 +}
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2022-09-05 23:51:29.933461688 +0300
 @@ -0,0 +1,631 @@
 +// Common/String.h
 +
@@ -33544,9 +33544,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +typedef CObjectVector<CSysString> CSysStringVector;
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,68 @@
 +// Common/StringToInt.cpp
 +
@@ -33616,9 +33616,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +    return -(Int64)ConvertStringToUInt64(s + 1, end);
 +  return ConvertStringToUInt64(s, end);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,17 @@
 +// Common/StringToInt.h
 +
@@ -33637,9 +33637,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,19 @@
 +// Common/Types.h
 +
@@ -33660,9 +33660,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,74 @@
 +// Common/Vector.cpp
 +
@@ -33738,9 +33738,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +    _size -= num;
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,211 @@
 +// Common/Vector.h
 +
@@ -33953,9 +33953,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +};
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,18 @@
 +// Windows/Defs.h
 +
@@ -33975,9 +33975,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.
 +  { return (value != VARIANT_FALSE); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,245 @@
 +// Windows/FileIO.cpp
 +
@@ -34224,9 +34224,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +}
 +
 +}}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,98 @@
 +// Windows/FileIO.h
 +
@@ -34326,9 +34326,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +}}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -34339,9 +34339,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAf
 +#include "../Common/NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squashfs-tools-patched/LZMA/lzmadaptive/CPL.html
---- squashfs-tools/LZMA/lzmadaptive/CPL.html	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squashfs-tools-patched/LZMA/lzmadaptive/CPL.html
+--- squashfs-tools/LZMA/lzmadaptive/CPL.html	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,224 @@
 +<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 +<HTML><HEAD><TITLE>Common Public License - v 1.0</TITLE>
@@ -34567,9 +34567,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squash
 +any resulting litigation.</FONT> 
 +<P><FONT size=2></FONT><FONT size=2></FONT>
 +<P><FONT size=2></FONT></P></BODY></HTML>
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squashfs-tools-patched/LZMA/lzmadaptive/history.txt
---- squashfs-tools/LZMA/lzmadaptive/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squashfs-tools-patched/LZMA/lzmadaptive/history.txt
+--- squashfs-tools/LZMA/lzmadaptive/history.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,147 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -34718,9 +34718,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squ
 +  
 +
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt
---- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt
+--- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,504 @@
 +      GNU LESSER GENERAL PUBLIC LICENSE
 +           Version 2.1, February 1999
@@ -35226,9 +35226,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squash
 +That's all there is to it!
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt
---- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt
+--- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,637 @@
 +LZMA SDK 4.32
 +-------------
@@ -35867,9 +35867,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squash
 +
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt
---- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt
+--- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,114 @@
 +Compression method IDs (4.27)
 +-----------------------------
@@ -35985,9 +35985,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squ
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-tools-patched/LZMA/lzmalt/7zlzma.c
---- squashfs-tools/LZMA/lzmalt/7zlzma.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-tools-patched/LZMA/lzmalt/7zlzma.c
+--- squashfs-tools/LZMA/lzmalt/7zlzma.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,58 @@
 +#include "lzmalt.h"
 +
@@ -36047,9 +36047,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-to
 +#endif
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h
---- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h
+--- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,51 @@
 +#ifndef __COMPRESSION_BITCODER_H
 +#define __COMPRESSION_BITCODER_H
@@ -36102,9 +36102,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squash
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h
---- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h
+--- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,160 @@
 +#ifndef __BITTREECODER_H
 +#define __BITTREECODER_H
@@ -36266,9 +36266,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squas
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c
+--- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,39 @@
 +#include "stdlib.h"
 +#include "IInOutStreams.h"
@@ -36309,9 +36309,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squa
 +        return (BYTE) *in_stream.data++;
 +    }
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h
+--- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,62 @@
 +#ifndef __IINOUTSTREAMS_H
 +#define __IINOUTSTREAMS_H
@@ -36375,9 +36375,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squa
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-tools-patched/LZMA/lzmalt/LenCoder.h
---- squashfs-tools/LZMA/lzmalt/LenCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-tools-patched/LZMA/lzmalt/LenCoder.h
+--- squashfs-tools/LZMA/lzmalt/LenCoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,75 @@
 +#ifndef __LENCODER_H
 +#define __LENCODER_H
@@ -36454,9 +36454,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h
---- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h
+--- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,146 @@
 +#ifndef __LITERALCODER_H
 +#define __LITERALCODER_H
@@ -36604,9 +36604,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squas
 +  }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c
+--- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,417 @@
 +#include "Portable.h"
 +#include "stdio.h"
@@ -37025,9 +37025,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squash
 +  return S_OK;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h
+--- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,60 @@
 +#ifndef __LZARITHMETIC_DECODER_H
 +#define __LZARITHMETIC_DECODER_H
@@ -37089,9 +37089,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squash
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tools-patched/LZMA/lzmalt/LZMA.h
---- squashfs-tools/LZMA/lzmalt/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tools-patched/LZMA/lzmalt/LZMA.h
+--- squashfs-tools/LZMA/lzmalt/LZMA.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,83 @@
 +#include "LenCoder.h"
 +
@@ -37176,9 +37176,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tool
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-tools-patched/LZMA/lzmalt/lzmalt.h
---- squashfs-tools/LZMA/lzmalt/lzmalt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-tools-patched/LZMA/lzmalt/lzmalt.h
+--- squashfs-tools/LZMA/lzmalt/lzmalt.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,16 @@
 +#ifndef __7Z_H
 +#define __7Z_H
@@ -37196,9 +37196,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-to
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-tools-patched/LZMA/lzmalt/Makefile
---- squashfs-tools/LZMA/lzmalt/Makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-tools-patched/LZMA/lzmalt/Makefile
+--- squashfs-tools/LZMA/lzmalt/Makefile	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,10 @@
 +INCLUDEDIR = .
 +
@@ -37210,9 +37210,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-to
 +
 +clean :
 +	rm -f *.o
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-tools-patched/LZMA/lzmalt/Portable.h
---- squashfs-tools/LZMA/lzmalt/Portable.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-tools-patched/LZMA/lzmalt/Portable.h
+--- squashfs-tools/LZMA/lzmalt/Portable.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,59 @@
 +#ifndef __PORTABLE_H
 +#define __PORTABLE_H
@@ -37273,9 +37273,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-
 +#define RETURN_IF_NOT_S_OK(x) { HRESULT __aResult_ = (x); if(__aResult_ != S_OK) return __aResult_; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h
---- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h
+--- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,56 @@
 +#ifndef __COMPRESSION_RANGECODER_H
 +#define __COMPRESSION_RANGECODER_H
@@ -37333,9 +37333,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashf
 +  }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-tools-patched/LZMA/lzmalt/RCDefs.h
---- squashfs-tools/LZMA/lzmalt/RCDefs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-tools-patched/LZMA/lzmalt/RCDefs.h
+--- squashfs-tools/LZMA/lzmalt/RCDefs.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,43 @@
 +#ifndef __RCDEFS_H
 +#define __RCDEFS_H
@@ -37380,9 +37380,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-to
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h
---- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h
+--- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,289 @@
 +/* vxTypesOld.h - old VxWorks type definition header */
 +
@@ -37673,9 +37673,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashf
 +#endif
 +
 +#endif /* __INCvxTypesOldh */
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs-tools-patched/LZMA/lzmalt/WindowOut.h
---- squashfs-tools/LZMA/lzmalt/WindowOut.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs-tools-patched/LZMA/lzmalt/WindowOut.h
+--- squashfs-tools/LZMA/lzmalt/WindowOut.h	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,52 @@
 +#ifndef __STREAM_WINDOWOUT_H
 +#define __STREAM_WINDOWOUT_H
@@ -37729,9 +37729,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-patched/lzma_wrapper.c
---- squashfs-tools/lzma_wrapper.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/lzma_wrapper.c	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-patched/lzma_wrapper.c
+--- squashfs-tools/lzma_wrapper.c	2014-03-09 07:31:58.000000000 +0200
++++ squashfs-tools-patched/lzma_wrapper.c	2022-09-05 23:51:29.937461817 +0300
 @@ -27,14 +27,21 @@
  #include "squashfs_fs.h"
  #include "compressor.h"
@@ -38076,9 +38076,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
 +	.supported = 1
 +};
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/Makefile
---- squashfs-tools/Makefile	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/Makefile	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/Makefile
+--- squashfs-tools/Makefile	2014-05-11 21:56:00.000000000 +0300
++++ squashfs-tools-patched/Makefile	2022-09-05 23:51:29.937461817 +0300
 @@ -26,7 +26,7 @@
  # To build using XZ Utils liblzma - install the library and uncomment
  # the XZ_SUPPORT line below.
@@ -38214,9 +38214,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
 -	cp mksquashfs $(INSTALL_DIR)
 -	cp unsquashfs $(INSTALL_DIR)
 +	cp sasquatch $(INSTALL_DIR)
-diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-tools-patched/process_fragments.c
---- squashfs-tools/process_fragments.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/process_fragments.c	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-tools-patched/process_fragments.c
+--- squashfs-tools/process_fragments.c	2014-05-10 07:54:13.000000000 +0300
++++ squashfs-tools-patched/process_fragments.c	2022-09-05 23:51:29.937461817 +0300
 @@ -192,9 +192,10 @@
  
  		res = compressor_uncompress(comp, buffer->data, data, size,
@@ -38231,9 +38231,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-too
  	} else if(compressed_buffer)
  		memcpy(buffer->data, compressed_buffer->data, size);
  	else {
-diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched/read_fs.c
---- squashfs-tools/read_fs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/read_fs.c	2016-08-25 09:06:03.231530353 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched/read_fs.c
+--- squashfs-tools/read_fs.c	2014-05-10 07:54:13.000000000 +0300
++++ squashfs-tools-patched/read_fs.c	2022-09-05 23:51:29.937461817 +0300
 @@ -87,8 +87,9 @@
  		res = compressor_uncompress(comp, block, buffer, c_byte,
  			outlen, &error);
@@ -38246,15 +38246,15 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched
  			return 0;
  		}
  	} else {
-diff --strip-trailing-cr -NBbaur squashfs-tools/README.md squashfs-tools-patched/README.md
---- squashfs-tools/README.md	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/README.md	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/README.md squashfs-tools-patched/README.md
+--- squashfs-tools/README.md	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/README.md	2022-09-05 23:51:29.937461817 +0300
 @@ -0,0 +1,2 @@
 +This is the raw, patched source code for squashfs-tools. It is included in this repository for documentation and administrative purposes only. Any bugs or patches not directly related to the modifications made by the sasquatch patches should be reported to the squashfs-tools project.
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-patched/squashfs_fs.h
---- squashfs-tools/squashfs_fs.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/squashfs_fs.h	2016-08-25 09:06:03.223530354 -0400
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-patched/squashfs_fs.h
+--- squashfs-tools/squashfs_fs.h	2014-05-10 07:54:13.000000000 +0300
++++ squashfs-tools-patched/squashfs_fs.h	2022-09-05 23:51:29.937461817 +0300
 @@ -277,6 +277,22 @@
  #define LZO_COMPRESSION		3
  #define XZ_COMPRESSION		4
@@ -38300,19 +38300,18 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-pat
 +};
 +
  #endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
---- squashfs-tools/unsquashfs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/unsquashfs.c	2016-08-25 09:06:03.223530354 -0400
-@@ -32,7 +32,8 @@
- #include "stdarg.h"
-
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
+--- squashfs-tools/unsquashfs.c	2014-05-13 01:18:35.000000000 +0300
++++ squashfs-tools-patched/unsquashfs.c	2022-09-05 23:52:45.891916303 +0300
+@@ -33,6 +33,7 @@
+ 
  #include <sys/sysinfo.h>
  #include <sys/types.h>
 +#include <sys/sysmacros.h>
  #include <sys/time.h>
  #include <sys/resource.h>
  #include <limits.h>
-@@ -44,13 +44,19 @@
+@@ -44,13 +45,22 @@
  pthread_mutex_t	fragment_mutex;
  
  /* user options that control parallelisation */
@@ -38321,6 +38320,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 +// CJH: Temporarily set the default processor count to 1 to prevent threading bug
 +//      until a proper fix is implemented.
 +int processors = 1;
++
++// CJH: Updated so that TRACE prints if -verbose is specified on the command line
++int verbose = FALSE;
  
  struct super_block sBlk;
  squashfs_operations s_ops;
@@ -38336,7 +38338,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	dev_count = 0, fifo_count = 0;
  char *inode_table = NULL, *directory_table = NULL;
  struct hash_table_entry *inode_table_hash[65536], *directory_table_hash[65536];
-@@ -701,8 +707,9 @@
+@@ -701,8 +711,9 @@
  			outlen, &error);
  
  		if(res == -1) {
@@ -38348,7 +38350,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  			goto failed;
  		}
  	} else {
-@@ -720,7 +727,10 @@
+@@ -720,7 +731,10 @@
  	 * is of the expected size
  	 */
  	if(expected && expected != res)
@@ -38359,7 +38361,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	else
  		return res;
  
-@@ -747,8 +757,9 @@
+@@ -747,8 +761,9 @@
  			block_size, &error);
  
  		if(res == -1) {
@@ -38371,7 +38373,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  			goto failed;
  		}
  
-@@ -1622,7 +1633,7 @@
+@@ -1622,7 +1637,7 @@
  	dir_count ++;
  }
  
@@ -38380,7 +38382,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  void squashfs_stat(char *source)
  {
  	time_t mkfs_time = (time_t) sBlk.s.mkfs_time;
-@@ -1640,9 +1651,10 @@
+@@ -1640,9 +1655,10 @@
  
  	printf("Creation or last append time %s", mkfs_str ? mkfs_str :
  		"failed to get time\n");
@@ -38394,7 +38396,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  
  	if(sBlk.s.s_major == 4) {
  		printf("Compression %s\n", comp->name);
-@@ -1714,25 +1726,25 @@
+@@ -1714,25 +1730,25 @@
  		printf("Number of gids %d\n", sBlk.no_guids);
  	}
  
@@ -38428,7 +38430,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	}
  }
  
-@@ -1745,9 +1757,11 @@
+@@ -1745,9 +1761,11 @@
  	if(!comp->supported) {
  		ERROR("Filesystem uses %s compression, this is "
  			"unsupported by this version\n", comp->name);
@@ -38443,7 +38445,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	}
  
  	/*
-@@ -1777,17 +1791,74 @@
+@@ -1777,17 +1795,76 @@
  {
  	squashfs_super_block_3 sBlk_3;
  	struct squashfs_super_block sBlk_4;
@@ -38488,7 +38490,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 +
 +    // CJH: Notify if endianess is different
 +    if(swap)
++    {
 +        ERROR("Reading a different endian SQUASHFS filesystem on %s\n", source);
++    }
  
  	/*
  	 * Try to read a Squashfs 4 superblock
@@ -38519,7 +38523,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		s_ops.squashfs_opendir = squashfs_opendir_4;
  		s_ops.read_fragment = read_fragment_4;
  		s_ops.read_fragment_table = read_fragment_table_4;
-@@ -1799,7 +1870,11 @@
+@@ -1799,7 +1876,11 @@
  		/*
  		 * Check the compression type
  		 */
@@ -38531,7 +38535,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		return TRUE;
  	}
  
-@@ -1813,6 +1888,9 @@
+@@ -1813,6 +1894,9 @@
  	/*
  	 * Check it is a SQUASHFS superblock
  	 */
@@ -38541,7 +38545,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	swap = 0;
  	if(sBlk_3.s_magic != SQUASHFS_MAGIC) {
  		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP) {
-@@ -1828,6 +1906,13 @@
+@@ -1828,6 +1912,13 @@
  			goto failed_mount;
  		}
  	}
@@ -38555,7 +38559,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  
  	sBlk.s.s_magic = sBlk_3.s_magic;
  	sBlk.s.inodes = sBlk_3.inodes;
-@@ -1850,14 +1935,22 @@
+@@ -1850,14 +1941,22 @@
  	sBlk.guid_start = sBlk_3.guid_start;
  	sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
  
@@ -38579,7 +38583,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		if(sBlk.s.s_major == 1) {
  			sBlk.s.block_size = sBlk_3.block_size_1;
  			sBlk.s.fragment_table_start = sBlk.uid_start;
-@@ -1893,7 +1986,11 @@
+@@ -1893,7 +1992,11 @@
  	/*
  	 * 1.x, 2.x and 3.x filesystems use gzip compression.
  	 */
@@ -38591,7 +38595,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	return TRUE;
  
  failed_mount:
-@@ -2106,11 +2203,15 @@
+@@ -2106,11 +2209,15 @@
  			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size), block_size,
  			&error);
  
@@ -38607,7 +38611,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  
  		/*
  		 * block has been either successfully decompressed, or an error
-@@ -2505,6 +2606,9 @@
+@@ -2505,6 +2612,9 @@
  	int fragment_buffer_size = FRAGMENT_BUFFER_DEFAULT;
  	int data_buffer_size = DATA_BUFFER_DEFAULT;
  
@@ -38617,7 +38621,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	pthread_mutex_init(&screen_mutex, NULL);
  	root_process = geteuid() == 0;
  	if(root_process)
-@@ -2611,6 +2715,83 @@
+@@ -2611,6 +2721,83 @@
  		} else if(strcmp(argv[i], "-regex") == 0 ||
  				strcmp(argv[i], "-r") == 0)
  			use_regex = TRUE;
@@ -38701,7 +38705,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		else
  			goto options;
  	}
-@@ -2674,6 +2855,22 @@
+@@ -2674,6 +2861,22 @@
  				"regular expressions\n");
  			ERROR("\t\t\t\trather than use the default shell "
  				"wildcard\n\t\t\t\texpansion (globbing)\n");
@@ -38724,3 +38728,2821 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  			ERROR("\nDecompressors available:\n");
  			display_compressors("", "");
  		}
+diff --color --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c.orig squashfs-tools-patched/unsquashfs.c.orig
+--- squashfs-tools/unsquashfs.c.orig	1970-01-01 02:00:00.000000000 +0200
++++ squashfs-tools-patched/unsquashfs.c.orig	2014-05-13 01:18:35.000000000 +0300
+@@ -0,0 +1,2814 @@
++/*
++ * Unsquash a squashfs filesystem.  This is a highly compressed read only
++ * filesystem.
++ *
++ * Copyright (c) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
++ * 2012, 2013, 2014
++ * Phillip Lougher <phillip@squashfs.org.uk>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * as published by the Free Software Foundation; either version 2,
++ * or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *
++ * unsquashfs.c
++ */
++
++#include "unsquashfs.h"
++#include "squashfs_swap.h"
++#include "squashfs_compat.h"
++#include "compressor.h"
++#include "xattr.h"
++#include "unsquashfs_info.h"
++#include "stdarg.h"
++
++#include <sys/sysinfo.h>
++#include <sys/types.h>
++#include <sys/time.h>
++#include <sys/resource.h>
++#include <limits.h>
++#include <ctype.h>
++
++struct cache *fragment_cache, *data_cache;
++struct queue *to_reader, *to_inflate, *to_writer, *from_writer;
++pthread_t *thread, *inflator_thread;
++pthread_mutex_t	fragment_mutex;
++
++/* user options that control parallelisation */
++int processors = -1;
++
++struct super_block sBlk;
++squashfs_operations s_ops;
++struct compressor *comp;
++
++int bytes = 0, swap, file_count = 0, dir_count = 0, sym_count = 0,
++	dev_count = 0, fifo_count = 0;
++char *inode_table = NULL, *directory_table = NULL;
++struct hash_table_entry *inode_table_hash[65536], *directory_table_hash[65536];
++int fd;
++unsigned int *uid_table, *guid_table;
++unsigned int cached_frag = SQUASHFS_INVALID_FRAG;
++char *fragment_data;
++char *file_data;
++char *data;
++unsigned int block_size;
++unsigned int block_log;
++int lsonly = FALSE, info = FALSE, force = FALSE, short_ls = TRUE;
++int use_regex = FALSE;
++char **created_inode;
++int root_process;
++int columns;
++int rotate = 0;
++pthread_mutex_t	screen_mutex;
++int progress = TRUE, progress_enabled = FALSE;
++unsigned int total_blocks = 0, total_files = 0, total_inodes = 0;
++unsigned int cur_blocks = 0;
++int inode_number = 1;
++int no_xattrs = XATTR_DEF;
++int user_xattrs = FALSE;
++
++int lookup_type[] = {
++	0,
++	S_IFDIR,
++	S_IFREG,
++	S_IFLNK,
++	S_IFBLK,
++	S_IFCHR,
++	S_IFIFO,
++	S_IFSOCK,
++	S_IFDIR,
++	S_IFREG,
++	S_IFLNK,
++	S_IFBLK,
++	S_IFCHR,
++	S_IFIFO,
++	S_IFSOCK
++};
++
++struct test table[] = {
++	{ S_IFMT, S_IFSOCK, 0, 's' },
++	{ S_IFMT, S_IFLNK, 0, 'l' },
++	{ S_IFMT, S_IFBLK, 0, 'b' },
++	{ S_IFMT, S_IFDIR, 0, 'd' },
++	{ S_IFMT, S_IFCHR, 0, 'c' },
++	{ S_IFMT, S_IFIFO, 0, 'p' },
++	{ S_IRUSR, S_IRUSR, 1, 'r' },
++	{ S_IWUSR, S_IWUSR, 2, 'w' },
++	{ S_IRGRP, S_IRGRP, 4, 'r' },
++	{ S_IWGRP, S_IWGRP, 5, 'w' },
++	{ S_IROTH, S_IROTH, 7, 'r' },
++	{ S_IWOTH, S_IWOTH, 8, 'w' },
++	{ S_IXUSR | S_ISUID, S_IXUSR | S_ISUID, 3, 's' },
++	{ S_IXUSR | S_ISUID, S_ISUID, 3, 'S' },
++	{ S_IXUSR | S_ISUID, S_IXUSR, 3, 'x' },
++	{ S_IXGRP | S_ISGID, S_IXGRP | S_ISGID, 6, 's' },
++	{ S_IXGRP | S_ISGID, S_ISGID, 6, 'S' },
++	{ S_IXGRP | S_ISGID, S_IXGRP, 6, 'x' },
++	{ S_IXOTH | S_ISVTX, S_IXOTH | S_ISVTX, 9, 't' },
++	{ S_IXOTH | S_ISVTX, S_ISVTX, 9, 'T' },
++	{ S_IXOTH | S_ISVTX, S_IXOTH, 9, 'x' },
++	{ 0, 0, 0, 0}
++};
++
++void progress_bar(long long current, long long max, int columns);
++
++#define MAX_LINE 16384
++
++void prep_exit()
++{
++}
++
++
++void sigwinch_handler()
++{
++	struct winsize winsize;
++
++	if(ioctl(1, TIOCGWINSZ, &winsize) == -1) {
++		if(isatty(STDOUT_FILENO))
++			ERROR("TIOCGWINSZ ioctl failed, defaulting to 80 "
++				"columns\n");
++		columns = 80;
++	} else
++		columns = winsize.ws_col;
++}
++
++
++void sigalrm_handler()
++{
++	rotate = (rotate + 1) % 4;
++}
++
++
++int add_overflow(int a, int b)
++{
++	return (INT_MAX - a) < b;
++}
++
++
++int shift_overflow(int a, int shift)
++{
++	return (INT_MAX >> shift) < a;
++}
++
++ 
++int multiply_overflow(int a, int multiplier)
++{
++	return (INT_MAX / multiplier) < a;
++}
++
++
++struct queue *queue_init(int size)
++{
++	struct queue *queue = malloc(sizeof(struct queue));
++
++	if(queue == NULL)
++		EXIT_UNSQUASH("Out of memory in queue_init\n");
++
++	if(add_overflow(size, 1) ||
++				multiply_overflow(size + 1, sizeof(void *)))
++		EXIT_UNSQUASH("Size too large in queue_init\n");
++
++	queue->data = malloc(sizeof(void *) * (size + 1));
++	if(queue->data == NULL)
++		EXIT_UNSQUASH("Out of memory in queue_init\n");
++
++	queue->size = size + 1;
++	queue->readp = queue->writep = 0;
++	pthread_mutex_init(&queue->mutex, NULL);
++	pthread_cond_init(&queue->empty, NULL);
++	pthread_cond_init(&queue->full, NULL);
++
++	return queue;
++}
++
++
++void queue_put(struct queue *queue, void *data)
++{
++	int nextp;
++
++	pthread_mutex_lock(&queue->mutex);
++
++	while((nextp = (queue->writep + 1) % queue->size) == queue->readp)
++		pthread_cond_wait(&queue->full, &queue->mutex);
++
++	queue->data[queue->writep] = data;
++	queue->writep = nextp;
++	pthread_cond_signal(&queue->empty);
++	pthread_mutex_unlock(&queue->mutex);
++}
++
++
++void *queue_get(struct queue *queue)
++{
++	void *data;
++	pthread_mutex_lock(&queue->mutex);
++
++	while(queue->readp == queue->writep)
++		pthread_cond_wait(&queue->empty, &queue->mutex);
++
++	data = queue->data[queue->readp];
++	queue->readp = (queue->readp + 1) % queue->size;
++	pthread_cond_signal(&queue->full);
++	pthread_mutex_unlock(&queue->mutex);
++
++	return data;
++}
++
++
++void dump_queue(struct queue *queue)
++{
++	pthread_mutex_lock(&queue->mutex);
++
++	printf("Max size %d, size %d%s\n", queue->size - 1,  
++		queue->readp <= queue->writep ? queue->writep - queue->readp :
++			queue->size - queue->readp + queue->writep,
++		queue->readp == queue->writep ? " (EMPTY)" :
++			((queue->writep + 1) % queue->size) == queue->readp ?
++			" (FULL)" : "");
++
++	pthread_mutex_unlock(&queue->mutex);
++}
++
++
++/* Called with the cache mutex held */
++void insert_hash_table(struct cache *cache, struct cache_entry *entry)
++{
++	int hash = CALCULATE_HASH(entry->block);
++
++	entry->hash_next = cache->hash_table[hash];
++	cache->hash_table[hash] = entry;
++	entry->hash_prev = NULL;
++	if(entry->hash_next)
++		entry->hash_next->hash_prev = entry;
++}
++
++
++/* Called with the cache mutex held */
++void remove_hash_table(struct cache *cache, struct cache_entry *entry)
++{
++	if(entry->hash_prev)
++		entry->hash_prev->hash_next = entry->hash_next;
++	else
++		cache->hash_table[CALCULATE_HASH(entry->block)] =
++			entry->hash_next;
++	if(entry->hash_next)
++		entry->hash_next->hash_prev = entry->hash_prev;
++
++	entry->hash_prev = entry->hash_next = NULL;
++}
++
++
++/* Called with the cache mutex held */
++void insert_free_list(struct cache *cache, struct cache_entry *entry)
++{
++	if(cache->free_list) {
++		entry->free_next = cache->free_list;
++		entry->free_prev = cache->free_list->free_prev;
++		cache->free_list->free_prev->free_next = entry;
++		cache->free_list->free_prev = entry;
++	} else {
++		cache->free_list = entry;
++		entry->free_prev = entry->free_next = entry;
++	}
++}
++
++
++/* Called with the cache mutex held */
++void remove_free_list(struct cache *cache, struct cache_entry *entry)
++{
++	if(entry->free_prev == NULL || entry->free_next == NULL)
++		/* not in free list */
++		return;
++	else if(entry->free_prev == entry && entry->free_next == entry) {
++		/* only this entry in the free list */
++		cache->free_list = NULL;
++	} else {
++		/* more than one entry in the free list */
++		entry->free_next->free_prev = entry->free_prev;
++		entry->free_prev->free_next = entry->free_next;
++		if(cache->free_list == entry)
++			cache->free_list = entry->free_next;
++	}
++
++	entry->free_prev = entry->free_next = NULL;
++}
++
++
++struct cache *cache_init(int buffer_size, int max_buffers)
++{
++	struct cache *cache = malloc(sizeof(struct cache));
++
++	if(cache == NULL)
++		EXIT_UNSQUASH("Out of memory in cache_init\n");
++
++	cache->max_buffers = max_buffers;
++	cache->buffer_size = buffer_size;
++	cache->count = 0;
++	cache->used = 0;
++	cache->free_list = NULL;
++	memset(cache->hash_table, 0, sizeof(struct cache_entry *) * 65536);
++	cache->wait_free = FALSE;
++	cache->wait_pending = FALSE;
++	pthread_mutex_init(&cache->mutex, NULL);
++	pthread_cond_init(&cache->wait_for_free, NULL);
++	pthread_cond_init(&cache->wait_for_pending, NULL);
++
++	return cache;
++}
++
++
++struct cache_entry *cache_get(struct cache *cache, long long block, int size)
++{
++	/*
++	 * Get a block out of the cache.  If the block isn't in the cache
++ 	 * it is added and queued to the reader() and inflate() threads for
++ 	 * reading off disk and decompression.  The cache grows until max_blocks
++ 	 * is reached, once this occurs existing discarded blocks on the free
++ 	 * list are reused
++ 	 */
++	int hash = CALCULATE_HASH(block);
++	struct cache_entry *entry;
++
++	pthread_mutex_lock(&cache->mutex);
++
++	for(entry = cache->hash_table[hash]; entry; entry = entry->hash_next)
++		if(entry->block == block)
++			break;
++
++	if(entry) {
++		/*
++ 		 * found the block in the cache.  If the block is currently unused
++		 * remove it from the free list and increment cache used count.
++ 		 */
++		if(entry->used == 0) {
++			cache->used ++;
++			remove_free_list(cache, entry);
++		}
++		entry->used ++;
++		pthread_mutex_unlock(&cache->mutex);
++	} else {
++		/*
++ 		 * not in the cache
++		 *
++		 * first try to allocate new block
++		 */
++		if(cache->count < cache->max_buffers) {
++			entry = malloc(sizeof(struct cache_entry));
++			if(entry == NULL)
++				EXIT_UNSQUASH("Out of memory in cache_get\n");
++			entry->data = malloc(cache->buffer_size);
++			if(entry->data == NULL)
++				EXIT_UNSQUASH("Out of memory in cache_get\n");
++			entry->cache = cache;
++			entry->free_prev = entry->free_next = NULL;
++			cache->count ++;
++		} else {
++			/*
++			 * try to get from free list
++			 */
++			while(cache->free_list == NULL) {
++				cache->wait_free = TRUE;
++				pthread_cond_wait(&cache->wait_for_free,
++					&cache->mutex);
++			}
++			entry = cache->free_list;
++			remove_free_list(cache, entry);
++			remove_hash_table(cache, entry);
++		}
++
++		/*
++		 * Initialise block and insert into the hash table.
++		 * Increment used which tracks how many buffers in the
++		 * cache are actively in use (the other blocks, count - used,
++		 * are in the cache and available for lookup, but can also be
++		 * re-used).
++		 */
++		entry->block = block;
++		entry->size = size;
++		entry->used = 1;
++		entry->error = FALSE;
++		entry->pending = TRUE;
++		insert_hash_table(cache, entry);
++		cache->used ++;
++
++		/*
++		 * queue to read thread to read and ultimately (via the
++		 * decompress threads) decompress the buffer
++ 		 */
++		pthread_mutex_unlock(&cache->mutex);
++		queue_put(to_reader, entry);
++	}
++
++	return entry;
++}
++
++	
++void cache_block_ready(struct cache_entry *entry, int error)
++{
++	/*
++	 * mark cache entry as being complete, reading and (if necessary)
++ 	 * decompression has taken place, and the buffer is valid for use.
++ 	 * If an error occurs reading or decompressing, the buffer also 
++ 	 * becomes ready but with an error...
++ 	 */
++	pthread_mutex_lock(&entry->cache->mutex);
++	entry->pending = FALSE;
++	entry->error = error;
++
++	/*
++	 * if the wait_pending flag is set, one or more threads may be waiting
++	 * on this buffer
++	 */
++	if(entry->cache->wait_pending) {
++		entry->cache->wait_pending = FALSE;
++		pthread_cond_broadcast(&entry->cache->wait_for_pending);
++	}
++
++	pthread_mutex_unlock(&entry->cache->mutex);
++}
++
++
++void cache_block_wait(struct cache_entry *entry)
++{
++	/*
++	 * wait for this cache entry to become ready, when reading and (if
++	 * necessary) decompression has taken place
++	 */
++	pthread_mutex_lock(&entry->cache->mutex);
++
++	while(entry->pending) {
++		entry->cache->wait_pending = TRUE;
++		pthread_cond_wait(&entry->cache->wait_for_pending,
++			&entry->cache->mutex);
++	}
++
++	pthread_mutex_unlock(&entry->cache->mutex);
++}
++
++
++void cache_block_put(struct cache_entry *entry)
++{
++	/*
++	 * finished with this cache entry, once the usage count reaches zero it
++ 	 * can be reused and is put onto the free list.  As it remains
++ 	 * accessible via the hash table it can be found getting a new lease of
++ 	 * life before it is reused.
++ 	 */
++	pthread_mutex_lock(&entry->cache->mutex);
++
++	entry->used --;
++	if(entry->used == 0) {
++		insert_free_list(entry->cache, entry);
++		entry->cache->used --;
++
++		/*
++		 * if the wait_free flag is set, one or more threads may be
++		 * waiting on this buffer
++		 */
++		if(entry->cache->wait_free) {
++			entry->cache->wait_free = FALSE;
++			pthread_cond_broadcast(&entry->cache->wait_for_free);
++		}
++	}
++
++	pthread_mutex_unlock(&entry->cache->mutex);
++}
++
++
++void dump_cache(struct cache *cache)
++{
++	pthread_mutex_lock(&cache->mutex);
++
++	printf("Max buffers %d, Current size %d, Used %d,  %s\n",
++		cache->max_buffers, cache->count, cache->used,
++		cache->free_list ?  "Free buffers" : "No free buffers");
++
++	pthread_mutex_unlock(&cache->mutex);
++}
++
++
++char *modestr(char *str, int mode)
++{
++	int i;
++
++	strcpy(str, "----------");
++
++	for(i = 0; table[i].mask != 0; i++) {
++		if((mode & table[i].mask) == table[i].value)
++			str[table[i].position] = table[i].mode;
++	}
++
++	return str;
++}
++
++
++#define TOTALCHARS  25
++int print_filename(char *pathname, struct inode *inode)
++{
++	char str[11], dummy[12], dummy2[12]; /* overflow safe */
++	char *userstr, *groupstr;
++	int padchars;
++	struct passwd *user;
++	struct group *group;
++	struct tm *t;
++
++	if(short_ls) {
++		printf("%s\n", pathname);
++		return 1;
++	}
++
++	user = getpwuid(inode->uid);
++	if(user == NULL) {
++		int res = snprintf(dummy, 12, "%d", inode->uid);
++		if(res < 0)
++			EXIT_UNSQUASH("snprintf failed in print_filename()\n");
++		else if(res >= 12)
++			/* unsigned int shouldn't ever need more than 11 bytes
++			 * (including terminating '\0') to print in base 10 */
++			userstr = "*";
++		else
++			userstr = dummy;
++	} else
++		userstr = user->pw_name;
++		 
++	group = getgrgid(inode->gid);
++	if(group == NULL) {
++		int res = snprintf(dummy2, 12, "%d", inode->gid);
++		if(res < 0)
++			EXIT_UNSQUASH("snprintf failed in print_filename()\n");
++		else if(res >= 12)
++			/* unsigned int shouldn't ever need more than 11 bytes
++			 * (including terminating '\0') to print in base 10 */
++			groupstr = "*";
++		else
++			groupstr = dummy2;
++	} else
++		groupstr = group->gr_name;
++
++	printf("%s %s/%s ", modestr(str, inode->mode), userstr, groupstr);
++
++	switch(inode->mode & S_IFMT) {
++		case S_IFREG:
++		case S_IFDIR:
++		case S_IFSOCK:
++		case S_IFIFO:
++		case S_IFLNK:
++			padchars = TOTALCHARS - strlen(userstr) -
++				strlen(groupstr);
++
++			printf("%*lld ", padchars > 0 ? padchars : 0,
++				inode->data);
++			break;
++		case S_IFCHR:
++		case S_IFBLK:
++			padchars = TOTALCHARS - strlen(userstr) -
++				strlen(groupstr) - 7; 
++
++			printf("%*s%3d,%3d ", padchars > 0 ? padchars : 0, " ",
++				(int) inode->data >> 8, (int) inode->data &
++				0xff);
++			break;
++	}
++
++	t = localtime(&inode->time);
++
++	printf("%d-%02d-%02d %02d:%02d %s", t->tm_year + 1900, t->tm_mon + 1,
++		t->tm_mday, t->tm_hour, t->tm_min, pathname);
++	if((inode->mode & S_IFMT) == S_IFLNK)
++		printf(" -> %s", inode->symlink);
++	printf("\n");
++		
++	return 1;
++}
++	
++
++void add_entry(struct hash_table_entry *hash_table[], long long start,
++	int bytes)
++{
++	int hash = CALCULATE_HASH(start);
++	struct hash_table_entry *hash_table_entry;
++
++	hash_table_entry = malloc(sizeof(struct hash_table_entry));
++	if(hash_table_entry == NULL)
++		EXIT_UNSQUASH("Out of memory in add_entry\n");
++
++	hash_table_entry->start = start;
++	hash_table_entry->bytes = bytes;
++	hash_table_entry->next = hash_table[hash];
++	hash_table[hash] = hash_table_entry;
++}
++
++
++int lookup_entry(struct hash_table_entry *hash_table[], long long start)
++{
++	int hash = CALCULATE_HASH(start);
++	struct hash_table_entry *hash_table_entry;
++
++	for(hash_table_entry = hash_table[hash]; hash_table_entry;
++				hash_table_entry = hash_table_entry->next)
++
++		if(hash_table_entry->start == start)
++			return hash_table_entry->bytes;
++
++	return -1;
++}
++
++
++int read_fs_bytes(int fd, long long byte, int bytes, void *buff)
++{
++	off_t off = byte;
++	int res, count;
++
++	TRACE("read_bytes: reading from position 0x%llx, bytes %d\n", byte,
++		bytes);
++
++	if(lseek(fd, off, SEEK_SET) == -1) {
++		ERROR("Lseek failed because %s\n", strerror(errno));
++		return FALSE;
++	}
++
++	for(count = 0; count < bytes; count += res) {
++		res = read(fd, buff + count, bytes - count);
++		if(res < 1) {
++			if(res == 0) {
++				ERROR("Read on filesystem failed because "
++					"EOF\n");
++				return FALSE;
++			} else if(errno != EINTR) {
++				ERROR("Read on filesystem failed because %s\n",
++						strerror(errno));
++				return FALSE;
++			} else
++				res = 0;
++		}
++	}
++
++	return TRUE;
++}
++
++
++int read_block(int fd, long long start, long long *next, int expected,
++								void *block)
++{
++	unsigned short c_byte;
++	int offset = 2, res, compressed;
++	int outlen = expected ? expected : SQUASHFS_METADATA_SIZE;
++	
++	if(swap) {
++		if(read_fs_bytes(fd, start, 2, &c_byte) == FALSE)
++			goto failed;
++		c_byte = (c_byte >> 8) | ((c_byte & 0xff) << 8);
++	} else 
++		if(read_fs_bytes(fd, start, 2, &c_byte) == FALSE)
++			goto failed;
++
++	TRACE("read_block: block @0x%llx, %d %s bytes\n", start,
++		SQUASHFS_COMPRESSED_SIZE(c_byte), SQUASHFS_COMPRESSED(c_byte) ?
++		"compressed" : "uncompressed");
++
++	if(SQUASHFS_CHECK_DATA(sBlk.s.flags))
++		offset = 3;
++
++	compressed = SQUASHFS_COMPRESSED(c_byte);
++	c_byte = SQUASHFS_COMPRESSED_SIZE(c_byte);
++
++	/*
++	 * The block size should not be larger than
++	 * the uncompressed size (or max uncompressed size if
++	 * expected is 0)
++	 */
++	if(c_byte > outlen)
++		return 0;
++
++	if(compressed) {
++		char buffer[c_byte];
++		int error;
++
++		res = read_fs_bytes(fd, start + offset, c_byte, buffer);
++		if(res == FALSE)
++			goto failed;
++
++		res = compressor_uncompress(comp, block, buffer, c_byte,
++			outlen, &error);
++
++		if(res == -1) {
++			ERROR("%s uncompress failed with error code %d\n",
++				comp->name, error);
++			goto failed;
++		}
++	} else {
++		res = read_fs_bytes(fd, start + offset, c_byte, block);
++		if(res == FALSE)
++			goto failed;
++		res = c_byte;
++	}
++
++	if(next)
++		*next = start + offset + c_byte;
++
++	/*
++	 * if expected, then check the (uncompressed) return data
++	 * is of the expected size
++	 */
++	if(expected && expected != res)
++		return 0;
++	else
++		return res;
++
++failed:
++	ERROR("read_block: failed to read block @0x%llx\n", start);
++	return FALSE;
++}
++
++
++int read_data_block(long long start, unsigned int size, char *block)
++{
++	int error, res;
++	int c_byte = SQUASHFS_COMPRESSED_SIZE_BLOCK(size);
++
++	TRACE("read_data_block: block @0x%llx, %d %s bytes\n", start,
++		c_byte, SQUASHFS_COMPRESSED_BLOCK(size) ? "compressed" :
++		"uncompressed");
++
++	if(SQUASHFS_COMPRESSED_BLOCK(size)) {
++		if(read_fs_bytes(fd, start, c_byte, data) == FALSE)
++			goto failed;
++
++		res = compressor_uncompress(comp, block, data, c_byte,
++			block_size, &error);
++
++		if(res == -1) {
++			ERROR("%s uncompress failed with error code %d\n",
++				comp->name, error);
++			goto failed;
++		}
++
++		return res;
++	} else {
++		if(read_fs_bytes(fd, start, c_byte, block) == FALSE)
++			goto failed;
++
++		return c_byte;
++	}
++
++failed:
++	ERROR("read_data_block: failed to read block @0x%llx, size %d\n", start,
++		c_byte);
++	return FALSE;
++}
++
++
++int read_inode_table(long long start, long long end)
++{
++	int size = 0, bytes = 0, res;
++
++	TRACE("read_inode_table: start %lld, end %lld\n", start, end);
++
++	while(start < end) {
++		if(size - bytes < SQUASHFS_METADATA_SIZE) {
++			inode_table = realloc(inode_table, size +=
++				SQUASHFS_METADATA_SIZE);
++			if(inode_table == NULL) {
++				ERROR("Out of memory in read_inode_table");
++				goto failed;
++			}
++		}
++
++		add_entry(inode_table_hash, start, bytes);
++
++		res = read_block(fd, start, &start, 0, inode_table + bytes);
++		if(res == 0) {
++			ERROR("read_inode_table: failed to read block\n");
++			goto failed;
++		}
++		bytes += res;
++
++		/*
++		 * If this is not the last metadata block in the inode table
++		 * then it should be SQUASHFS_METADATA_SIZE in size.
++		 * Note, we can't use expected in read_block() above for this
++		 * because we don't know if this is the last block until
++		 * after reading.
++		 */
++		if(start != end && res != SQUASHFS_METADATA_SIZE) {
++			ERROR("read_inode_table: metadata block should be %d "
++				"bytes in length, it is %d bytes\n",
++				SQUASHFS_METADATA_SIZE, res);
++			
++			goto failed;
++		}
++	}
++
++	return TRUE;
++
++failed:
++	free(inode_table);
++	return FALSE;
++}
++
++
++int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
++	unsigned int xattr, unsigned int set_mode)
++{
++	struct utimbuf times = { time, time };
++
++	write_xattr(pathname, xattr);
++
++	if(utime(pathname, &times) == -1) {
++		ERROR("set_attributes: failed to set time on %s, because %s\n",
++			pathname, strerror(errno));
++		return FALSE;
++	}
++
++	if(root_process) {
++		if(chown(pathname, uid, guid) == -1) {
++			ERROR("set_attributes: failed to change uid and gids "
++				"on %s, because %s\n", pathname,
++				strerror(errno));
++			return FALSE;
++		}
++	} else
++		mode &= ~07000;
++
++	if((set_mode || (mode & 07000)) && chmod(pathname, (mode_t) mode) == -1) {
++		ERROR("set_attributes: failed to change mode %s, because %s\n",
++			pathname, strerror(errno));
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++
++int write_bytes(int fd, char *buff, int bytes)
++{
++	int res, count;
++
++	for(count = 0; count < bytes; count += res) {
++		res = write(fd, buff + count, bytes - count);
++		if(res == -1) {
++			if(errno != EINTR) {
++				ERROR("Write on output file failed because "
++					"%s\n", strerror(errno));
++				return -1;
++			}
++			res = 0;
++		}
++	}
++
++	return 0;
++}
++
++
++int lseek_broken = FALSE;
++char *zero_data = NULL;
++
++int write_block(int file_fd, char *buffer, int size, long long hole, int sparse)
++{
++	off_t off = hole;
++
++	if(hole) {
++		if(sparse && lseek_broken == FALSE) {
++			 int error = lseek(file_fd, off, SEEK_CUR);
++			 if(error == -1)
++				/* failed to seek beyond end of file */
++				lseek_broken = TRUE;
++		}
++
++		if((sparse == FALSE || lseek_broken) && zero_data == NULL) {
++			if((zero_data = malloc(block_size)) == NULL)
++				EXIT_UNSQUASH("write_block: failed to alloc "
++					"zero data block\n");
++			memset(zero_data, 0, block_size);
++		}
++
++		if(sparse == FALSE || lseek_broken) {
++			int blocks = (hole + block_size -1) / block_size;
++			int avail_bytes, i;
++			for(i = 0; i < blocks; i++, hole -= avail_bytes) {
++				avail_bytes = hole > block_size ? block_size :
++					hole;
++				if(write_bytes(file_fd, zero_data, avail_bytes)
++						== -1)
++					goto failure;
++			}
++		}
++	}
++
++	if(write_bytes(file_fd, buffer, size) == -1)
++		goto failure;
++
++	return TRUE;
++
++failure:
++	return FALSE;
++}
++
++
++pthread_mutex_t open_mutex = PTHREAD_MUTEX_INITIALIZER;
++pthread_cond_t open_empty = PTHREAD_COND_INITIALIZER;
++int open_unlimited, open_count;
++#define OPEN_FILE_MARGIN 10
++
++
++void open_init(int count)
++{
++	open_count = count;
++	open_unlimited = count == -1;
++}
++
++
++int open_wait(char *pathname, int flags, mode_t mode)
++{
++	if (!open_unlimited) {
++		pthread_mutex_lock(&open_mutex);
++		while (open_count == 0)
++			pthread_cond_wait(&open_empty, &open_mutex);
++		open_count --;
++		pthread_mutex_unlock(&open_mutex);
++	}
++
++	return open(pathname, flags, mode);
++}
++
++
++void close_wake(int fd)
++{
++	close(fd);
++
++	if (!open_unlimited) {
++		pthread_mutex_lock(&open_mutex);
++		open_count ++;
++		pthread_cond_signal(&open_empty);
++		pthread_mutex_unlock(&open_mutex);
++	}
++}
++
++
++void queue_file(char *pathname, int file_fd, struct inode *inode)
++{
++	struct squashfs_file *file = malloc(sizeof(struct squashfs_file));
++	if(file == NULL)
++		EXIT_UNSQUASH("queue_file: unable to malloc file\n");
++
++	file->fd = file_fd;
++	file->file_size = inode->data;
++	file->mode = inode->mode;
++	file->gid = inode->gid;
++	file->uid = inode->uid;
++	file->time = inode->time;
++	file->pathname = strdup(pathname);
++	file->blocks = inode->blocks + (inode->frag_bytes > 0);
++	file->sparse = inode->sparse;
++	file->xattr = inode->xattr;
++	queue_put(to_writer, file);
++}
++
++
++void queue_dir(char *pathname, struct dir *dir)
++{
++	struct squashfs_file *file = malloc(sizeof(struct squashfs_file));
++	if(file == NULL)
++		EXIT_UNSQUASH("queue_dir: unable to malloc file\n");
++
++	file->fd = -1;
++	file->mode = dir->mode;
++	file->gid = dir->guid;
++	file->uid = dir->uid;
++	file->time = dir->mtime;
++	file->pathname = strdup(pathname);
++	file->xattr = dir->xattr;
++	queue_put(to_writer, file);
++}
++
++
++int write_file(struct inode *inode, char *pathname)
++{
++	unsigned int file_fd, i;
++	unsigned int *block_list;
++	int file_end = inode->data / block_size;
++	long long start = inode->start;
++
++	TRACE("write_file: regular file, blocks %d\n", inode->blocks);
++
++	file_fd = open_wait(pathname, O_CREAT | O_WRONLY |
++		(force ? O_TRUNC : 0), (mode_t) inode->mode & 0777);
++	if(file_fd == -1) {
++		ERROR("write_file: failed to create file %s, because %s\n",
++			pathname, strerror(errno));
++		return FALSE;
++	}
++
++	block_list = malloc(inode->blocks * sizeof(unsigned int));
++	if(block_list == NULL)
++		EXIT_UNSQUASH("write_file: unable to malloc block list\n");
++
++	s_ops.read_block_list(block_list, inode->block_ptr, inode->blocks);
++
++	/*
++	 * the writer thread is queued a squashfs_file structure describing the
++ 	 * file.  If the file has one or more blocks or a fragment they are
++ 	 * queued separately (references to blocks in the cache).
++ 	 */
++	queue_file(pathname, file_fd, inode);
++
++	for(i = 0; i < inode->blocks; i++) {
++		int c_byte = SQUASHFS_COMPRESSED_SIZE_BLOCK(block_list[i]);
++		struct file_entry *block = malloc(sizeof(struct file_entry));
++
++		if(block == NULL)
++			EXIT_UNSQUASH("write_file: unable to malloc file\n");
++		block->offset = 0;
++		block->size = i == file_end ? inode->data & (block_size - 1) :
++			block_size;
++		if(block_list[i] == 0) /* sparse block */
++			block->buffer = NULL;
++		else {
++			block->buffer = cache_get(data_cache, start,
++				block_list[i]);
++			start += c_byte;
++		}
++		queue_put(to_writer, block);
++	}
++
++	if(inode->frag_bytes) {
++		int size;
++		long long start;
++		struct file_entry *block = malloc(sizeof(struct file_entry));
++
++		if(block == NULL)
++			EXIT_UNSQUASH("write_file: unable to malloc file\n");
++		s_ops.read_fragment(inode->fragment, &start, &size);
++		block->buffer = cache_get(fragment_cache, start, size);
++		block->offset = inode->offset;
++		block->size = inode->frag_bytes;
++		queue_put(to_writer, block);
++	}
++
++	free(block_list);
++	return TRUE;
++}
++
++
++int create_inode(char *pathname, struct inode *i)
++{
++	TRACE("create_inode: pathname %s\n", pathname);
++
++	if(created_inode[i->inode_number - 1]) {
++		TRACE("create_inode: hard link\n");
++		if(force)
++			unlink(pathname);
++
++		if(link(created_inode[i->inode_number - 1], pathname) == -1) {
++			ERROR("create_inode: failed to create hardlink, "
++				"because %s\n", strerror(errno));
++			return FALSE;
++		}
++
++		return TRUE;
++	}
++
++	switch(i->type) {
++		case SQUASHFS_FILE_TYPE:
++		case SQUASHFS_LREG_TYPE:
++			TRACE("create_inode: regular file, file_size %lld, "
++				"blocks %d\n", i->data, i->blocks);
++
++			if(write_file(i, pathname))
++				file_count ++;
++			break;
++		case SQUASHFS_SYMLINK_TYPE:
++		case SQUASHFS_LSYMLINK_TYPE:
++			TRACE("create_inode: symlink, symlink_size %lld\n",
++				i->data);
++
++			if(force)
++				unlink(pathname);
++
++			if(symlink(i->symlink, pathname) == -1) {
++				ERROR("create_inode: failed to create symlink "
++					"%s, because %s\n", pathname,
++					strerror(errno));
++				break;
++			}
++
++			write_xattr(pathname, i->xattr);
++	
++			if(root_process) {
++				if(lchown(pathname, i->uid, i->gid) == -1)
++					ERROR("create_inode: failed to change "
++						"uid and gids on %s, because "
++						"%s\n", pathname,
++						strerror(errno));
++			}
++
++			sym_count ++;
++			break;
++ 		case SQUASHFS_BLKDEV_TYPE:
++	 	case SQUASHFS_CHRDEV_TYPE:
++ 		case SQUASHFS_LBLKDEV_TYPE:
++	 	case SQUASHFS_LCHRDEV_TYPE: {
++			int chrdev = i->type == SQUASHFS_CHRDEV_TYPE;
++			TRACE("create_inode: dev, rdev 0x%llx\n", i->data);
++
++			if(root_process) {
++				if(force)
++					unlink(pathname);
++
++				if(mknod(pathname, chrdev ? S_IFCHR : S_IFBLK,
++						makedev((i->data >> 8) & 0xff,
++						i->data & 0xff)) == -1) {
++					ERROR("create_inode: failed to create "
++						"%s device %s, because %s\n",
++						chrdev ? "character" : "block",
++						pathname, strerror(errno));
++					break;
++				}
++				set_attributes(pathname, i->mode, i->uid,
++					i->gid, i->time, i->xattr, TRUE);
++				dev_count ++;
++			} else
++				ERROR("create_inode: could not create %s "
++					"device %s, because you're not "
++					"superuser!\n", chrdev ? "character" :
++					"block", pathname);
++			break;
++		}
++		case SQUASHFS_FIFO_TYPE:
++		case SQUASHFS_LFIFO_TYPE:
++			TRACE("create_inode: fifo\n");
++
++			if(force)
++				unlink(pathname);
++
++			if(mknod(pathname, S_IFIFO, 0) == -1) {
++				ERROR("create_inode: failed to create fifo %s, "
++					"because %s\n", pathname,
++					strerror(errno));
++				break;
++			}
++			set_attributes(pathname, i->mode, i->uid, i->gid,
++				i->time, i->xattr, TRUE);
++			fifo_count ++;
++			break;
++		case SQUASHFS_SOCKET_TYPE:
++		case SQUASHFS_LSOCKET_TYPE:
++			TRACE("create_inode: socket\n");
++			ERROR("create_inode: socket %s ignored\n", pathname);
++			break;
++		default:
++			ERROR("Unknown inode type %d in create_inode_table!\n",
++				i->type);
++			return FALSE;
++	}
++
++	created_inode[i->inode_number - 1] = strdup(pathname);
++
++	return TRUE;
++}
++
++
++int read_directory_table(long long start, long long end)
++{
++	int bytes = 0, size = 0, res;
++
++	TRACE("read_directory_table: start %lld, end %lld\n", start, end);
++
++	while(start < end) {
++		if(size - bytes < SQUASHFS_METADATA_SIZE) {
++			directory_table = realloc(directory_table, size +=
++				SQUASHFS_METADATA_SIZE);
++			if(directory_table == NULL) {
++				ERROR("Out of memory in "
++						"read_directory_table\n");
++				goto failed;
++			}
++		}
++
++		add_entry(directory_table_hash, start, bytes);
++
++		res = read_block(fd, start, &start, 0, directory_table + bytes);
++		if(res == 0) {
++			ERROR("read_directory_table: failed to read block\n");
++			goto failed;
++		}
++
++		bytes += res;
++
++		/*
++		 * If this is not the last metadata block in the directory table
++		 * then it should be SQUASHFS_METADATA_SIZE in size.
++		 * Note, we can't use expected in read_block() above for this
++		 * because we don't know if this is the last block until
++		 * after reading.
++		 */
++		if(start != end && res != SQUASHFS_METADATA_SIZE) {
++			ERROR("read_directory_table: metadata block "
++				"should be %d bytes in length, it is %d "
++				"bytes\n", SQUASHFS_METADATA_SIZE, res);
++			goto failed;
++		}
++	}
++
++	return TRUE;
++
++failed:
++	free(directory_table);
++	return FALSE;
++}
++
++
++int squashfs_readdir(struct dir *dir, char **name, unsigned int *start_block,
++unsigned int *offset, unsigned int *type)
++{
++	if(dir->cur_entry == dir->dir_count)
++		return FALSE;
++
++	*name = dir->dirs[dir->cur_entry].name;
++	*start_block = dir->dirs[dir->cur_entry].start_block;
++	*offset = dir->dirs[dir->cur_entry].offset;
++	*type = dir->dirs[dir->cur_entry].type;
++	dir->cur_entry ++;
++
++	return TRUE;
++}
++
++
++void squashfs_closedir(struct dir *dir)
++{
++	free(dir->dirs);
++	free(dir);
++}
++
++
++char *get_component(char *target, char **targname)
++{
++	char *start;
++
++	while(*target == '/')
++		target ++;
++
++	start = target;
++	while(*target != '/' && *target != '\0')
++		target ++;
++
++	*targname = strndup(start, target - start);
++
++	while(*target == '/')
++		target ++;
++
++	return target;
++}
++
++
++void free_path(struct pathname *paths)
++{
++	int i;
++
++	for(i = 0; i < paths->names; i++) {
++		if(paths->name[i].paths)
++			free_path(paths->name[i].paths);
++		free(paths->name[i].name);
++		if(paths->name[i].preg) {
++			regfree(paths->name[i].preg);
++			free(paths->name[i].preg);
++		}
++	}
++
++	free(paths);
++}
++
++
++struct pathname *add_path(struct pathname *paths, char *target, char *alltarget)
++{
++	char *targname;
++	int i, error;
++
++	TRACE("add_path: adding \"%s\" extract file\n", target);
++
++	target = get_component(target, &targname);
++
++	if(paths == NULL) {
++		paths = malloc(sizeof(struct pathname));
++		if(paths == NULL)
++			EXIT_UNSQUASH("failed to allocate paths\n");
++
++		paths->names = 0;
++		paths->name = NULL;
++	}
++
++	for(i = 0; i < paths->names; i++)
++		if(strcmp(paths->name[i].name, targname) == 0)
++			break;
++
++	if(i == paths->names) {
++		/*
++		 * allocate new name entry
++		 */
++		paths->names ++;
++		paths->name = realloc(paths->name, (i + 1) *
++			sizeof(struct path_entry));
++		if(paths->name == NULL)
++			EXIT_UNSQUASH("Out of memory in add_path\n");	
++		paths->name[i].name = targname;
++		paths->name[i].paths = NULL;
++		if(use_regex) {
++			paths->name[i].preg = malloc(sizeof(regex_t));
++			if(paths->name[i].preg == NULL)
++				EXIT_UNSQUASH("Out of memory in add_path\n");
++			error = regcomp(paths->name[i].preg, targname,
++				REG_EXTENDED|REG_NOSUB);
++			if(error) {
++				char str[1024]; /* overflow safe */
++
++				regerror(error, paths->name[i].preg, str, 1024);
++				EXIT_UNSQUASH("invalid regex %s in export %s, "
++					"because %s\n", targname, alltarget,
++					str);
++			}
++		} else
++			paths->name[i].preg = NULL;
++
++		if(target[0] == '\0')
++			/*
++			 * at leaf pathname component
++			*/
++			paths->name[i].paths = NULL;
++		else
++			/*
++			 * recurse adding child components
++			 */
++			paths->name[i].paths = add_path(NULL, target, alltarget);
++	} else {
++		/*
++		 * existing matching entry
++		 */
++		free(targname);
++
++		if(paths->name[i].paths == NULL) {
++			/*
++			 * No sub-directory which means this is the leaf
++			 * component of a pre-existing extract which subsumes
++			 * the extract currently being added, in which case stop
++			 * adding components
++			 */
++		} else if(target[0] == '\0') {
++			/*
++			 * at leaf pathname component and child components exist
++			 * from more specific extracts, delete as they're
++			 * subsumed by this extract
++			 */
++			free_path(paths->name[i].paths);
++			paths->name[i].paths = NULL;
++		} else
++			/*
++			 * recurse adding child components
++			 */
++			add_path(paths->name[i].paths, target, alltarget);
++	}
++
++	return paths;
++}
++
++
++struct pathnames *init_subdir()
++{
++	struct pathnames *new = malloc(sizeof(struct pathnames));
++	if(new == NULL)
++		EXIT_UNSQUASH("Out of memory in init_subdir\n");
++	new->count = 0;
++	return new;
++}
++
++
++struct pathnames *add_subdir(struct pathnames *paths, struct pathname *path)
++{
++	if(paths->count % PATHS_ALLOC_SIZE == 0) {
++		paths = realloc(paths, sizeof(struct pathnames *) +
++			(paths->count + PATHS_ALLOC_SIZE) *
++			sizeof(struct pathname *));
++		if(paths == NULL)
++			EXIT_UNSQUASH("Out of memory in add_subdir\n");
++	}
++
++	paths->path[paths->count++] = path;
++	return paths;
++}
++
++
++void free_subdir(struct pathnames *paths)
++{
++	free(paths);
++}
++
++
++int matches(struct pathnames *paths, char *name, struct pathnames **new)
++{
++	int i, n;
++
++	if(paths == NULL) {
++		*new = NULL;
++		return TRUE;
++	}
++
++	*new = init_subdir();
++
++	for(n = 0; n < paths->count; n++) {
++		struct pathname *path = paths->path[n];
++		for(i = 0; i < path->names; i++) {
++			int match = use_regex ?
++				regexec(path->name[i].preg, name, (size_t) 0,
++				NULL, 0) == 0 : fnmatch(path->name[i].name,
++				name, FNM_PATHNAME|FNM_PERIOD|FNM_EXTMATCH) ==
++				0;
++			if(match && path->name[i].paths == NULL)
++				/*
++				 * match on a leaf component, any subdirectories
++				 * will implicitly match, therefore return an
++				 * empty new search set
++				 */
++				goto empty_set;
++
++			if(match)
++				/*
++				 * match on a non-leaf component, add any
++				 * subdirectories to the new set of
++				 * subdirectories to scan for this name
++				 */
++				*new = add_subdir(*new, path->name[i].paths);
++		}
++	}
++
++	if((*new)->count == 0) {
++		/*
++		 * no matching names found, delete empty search set, and return
++		 * FALSE
++		 */
++		free_subdir(*new);
++		*new = NULL;
++		return FALSE;
++	}
++
++	/*
++	 * one or more matches with sub-directories found (no leaf matches),
++	 * return new search set and return TRUE
++	 */
++	return TRUE;
++
++empty_set:
++	/*
++	 * found matching leaf exclude, return empty search set and return TRUE
++	 */
++	free_subdir(*new);
++	*new = NULL;
++	return TRUE;
++}
++
++
++void pre_scan(char *parent_name, unsigned int start_block, unsigned int offset,
++	struct pathnames *paths)
++{
++	unsigned int type;
++	char *name;
++	struct pathnames *new;
++	struct inode *i;
++	struct dir *dir = s_ops.squashfs_opendir(start_block, offset, &i);
++
++	if(dir == NULL)
++		return;
++
++	while(squashfs_readdir(dir, &name, &start_block, &offset, &type)) {
++		struct inode *i;
++		char *pathname;
++		int res;
++
++		TRACE("pre_scan: name %s, start_block %d, offset %d, type %d\n",
++			name, start_block, offset, type);
++
++		if(!matches(paths, name, &new))
++			continue;
++
++		res = asprintf(&pathname, "%s/%s", parent_name, name);
++		if(res == -1)
++			EXIT_UNSQUASH("asprintf failed in dir_scan\n");
++
++		if(type == SQUASHFS_DIR_TYPE)
++			pre_scan(parent_name, start_block, offset, new);
++		else if(new == NULL) {
++			if(type == SQUASHFS_FILE_TYPE ||
++					type == SQUASHFS_LREG_TYPE) {
++				i = s_ops.read_inode(start_block, offset);
++				if(created_inode[i->inode_number - 1] == NULL) {
++					created_inode[i->inode_number - 1] =
++						(char *) i;
++					total_blocks += (i->data +
++						(block_size - 1)) >> block_log;
++				}
++				total_files ++;
++			}
++			total_inodes ++;
++		}
++
++		free_subdir(new);
++		free(pathname);
++	}
++
++	squashfs_closedir(dir);
++}
++
++
++void dir_scan(char *parent_name, unsigned int start_block, unsigned int offset,
++	struct pathnames *paths)
++{
++	unsigned int type;
++	char *name;
++	struct pathnames *new;
++	struct inode *i;
++	struct dir *dir = s_ops.squashfs_opendir(start_block, offset, &i);
++
++	if(dir == NULL) {
++		ERROR("dir_scan: failed to read directory %s, skipping\n",
++			parent_name);
++		return;
++	}
++
++	if(lsonly || info)
++		print_filename(parent_name, i);
++
++	if(!lsonly) {
++		/*
++		 * Make directory with default User rwx permissions rather than
++		 * the permissions from the filesystem, as these may not have
++		 * write/execute permission.  These are fixed up later in
++		 * set_attributes().
++		 */
++		int res = mkdir(parent_name, S_IRUSR|S_IWUSR|S_IXUSR);
++		if(res == -1) {
++			/*
++			 * Skip directory if mkdir fails, unless we're
++			 * forcing and the error is -EEXIST
++			 */
++			if(!force || errno != EEXIST) {
++				ERROR("dir_scan: failed to make directory %s, "
++					"because %s\n", parent_name,
++					strerror(errno));
++				squashfs_closedir(dir);
++				return;
++			} 
++
++			/*
++			 * Try to change permissions of existing directory so
++			 * that we can write to it
++			 */
++			res = chmod(parent_name, S_IRUSR|S_IWUSR|S_IXUSR);
++			if (res == -1)
++				ERROR("dir_scan: failed to change permissions "
++					"for directory %s, because %s\n",
++					parent_name, strerror(errno));
++		}
++	}
++
++	while(squashfs_readdir(dir, &name, &start_block, &offset, &type)) {
++		char *pathname;
++		int res;
++
++		TRACE("dir_scan: name %s, start_block %d, offset %d, type %d\n",
++			name, start_block, offset, type);
++
++
++		if(!matches(paths, name, &new))
++			continue;
++
++		res = asprintf(&pathname, "%s/%s", parent_name, name);
++		if(res == -1)
++			EXIT_UNSQUASH("asprintf failed in dir_scan\n");
++
++		if(type == SQUASHFS_DIR_TYPE) {
++			dir_scan(pathname, start_block, offset, new);
++			free(pathname);
++		} else if(new == NULL) {
++			update_info(pathname);
++
++			i = s_ops.read_inode(start_block, offset);
++
++			if(lsonly || info)
++				print_filename(pathname, i);
++
++			if(!lsonly)
++				create_inode(pathname, i);
++
++			if(i->type == SQUASHFS_SYMLINK_TYPE ||
++					i->type == SQUASHFS_LSYMLINK_TYPE)
++				free(i->symlink);
++		} else
++			free(pathname);
++
++		free_subdir(new);
++	}
++
++	if(!lsonly)
++		queue_dir(parent_name, dir);
++
++	squashfs_closedir(dir);
++	dir_count ++;
++}
++
++
++void squashfs_stat(char *source)
++{
++	time_t mkfs_time = (time_t) sBlk.s.mkfs_time;
++	char *mkfs_str = ctime(&mkfs_time);
++
++#if __BYTE_ORDER == __BIG_ENDIAN
++	printf("Found a valid %sSQUASHFS %d:%d superblock on %s.\n",
++		sBlk.s.s_major == 4 ? "" : swap ? "little endian " :
++		"big endian ", sBlk.s.s_major, sBlk.s.s_minor, source);
++#else
++	printf("Found a valid %sSQUASHFS %d:%d superblock on %s.\n",
++		sBlk.s.s_major == 4 ? "" : swap ? "big endian " :
++		"little endian ", sBlk.s.s_major, sBlk.s.s_minor, source);
++#endif
++
++	printf("Creation or last append time %s", mkfs_str ? mkfs_str :
++		"failed to get time\n");
++	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n",
++		sBlk.s.bytes_used / 1024.0, sBlk.s.bytes_used /
++		(1024.0 * 1024.0));
++
++	if(sBlk.s.s_major == 4) {
++		printf("Compression %s\n", comp->name);
++
++		if(SQUASHFS_COMP_OPTS(sBlk.s.flags)) {
++			char buffer[SQUASHFS_METADATA_SIZE] __attribute__ ((aligned));
++			int bytes;
++
++			bytes = read_block(fd, sizeof(sBlk.s), NULL, 0, buffer);
++			if(bytes == 0) {
++				ERROR("Failed to read compressor options\n");
++				return;
++			}
++
++			compressor_display_options(comp, buffer, bytes);
++		}
++	}
++
++	printf("Block size %d\n", sBlk.s.block_size);
++	printf("Filesystem is %sexportable via NFS\n",
++		SQUASHFS_EXPORTABLE(sBlk.s.flags) ? "" : "not ");
++	printf("Inodes are %scompressed\n",
++		SQUASHFS_UNCOMPRESSED_INODES(sBlk.s.flags) ? "un" : "");
++	printf("Data is %scompressed\n",
++		SQUASHFS_UNCOMPRESSED_DATA(sBlk.s.flags) ? "un" : "");
++
++	if(sBlk.s.s_major > 1) {
++		if(SQUASHFS_NO_FRAGMENTS(sBlk.s.flags))
++			printf("Fragments are not stored\n");
++		else {
++			printf("Fragments are %scompressed\n",
++				SQUASHFS_UNCOMPRESSED_FRAGMENTS(sBlk.s.flags) ?
++				"un" : "");
++			printf("Always-use-fragments option is %sspecified\n",
++				SQUASHFS_ALWAYS_FRAGMENTS(sBlk.s.flags) ? "" :
++				"not ");
++		}
++	}
++
++	if(sBlk.s.s_major == 4) {
++		if(SQUASHFS_NO_XATTRS(sBlk.s.flags))
++			printf("Xattrs are not stored\n");
++		else
++			printf("Xattrs are %scompressed\n",
++				SQUASHFS_UNCOMPRESSED_XATTRS(sBlk.s.flags) ?
++				"un" : "");
++	}
++
++	if(sBlk.s.s_major < 4)
++			printf("Check data is %spresent in the filesystem\n",
++				SQUASHFS_CHECK_DATA(sBlk.s.flags) ? "" :
++				"not ");
++
++	if(sBlk.s.s_major > 1)
++		printf("Duplicates are %sremoved\n",
++			SQUASHFS_DUPLICATES(sBlk.s.flags) ? "" : "not ");
++	else
++		printf("Duplicates are removed\n");
++
++	if(sBlk.s.s_major > 1)
++		printf("Number of fragments %d\n", sBlk.s.fragments);
++
++	printf("Number of inodes %d\n", sBlk.s.inodes);
++
++	if(sBlk.s.s_major == 4)
++		printf("Number of ids %d\n", sBlk.s.no_ids);
++	else {
++		printf("Number of uids %d\n", sBlk.no_uids);
++		printf("Number of gids %d\n", sBlk.no_guids);
++	}
++
++	TRACE("sBlk.s.inode_table_start 0x%llx\n", sBlk.s.inode_table_start);
++	TRACE("sBlk.s.directory_table_start 0x%llx\n",
++		sBlk.s.directory_table_start);
++
++	if(sBlk.s.s_major > 1)
++		TRACE("sBlk.s.fragment_table_start 0x%llx\n\n",
++			sBlk.s.fragment_table_start);
++
++	if(sBlk.s.s_major > 2)
++		TRACE("sBlk.s.lookup_table_start 0x%llx\n\n",
++			sBlk.s.lookup_table_start);
++
++	if(sBlk.s.s_major == 4) {
++		TRACE("sBlk.s.id_table_start 0x%llx\n", sBlk.s.id_table_start);
++		TRACE("sBlk.s.xattr_id_table_start 0x%llx\n",
++			sBlk.s.xattr_id_table_start);
++	} else {
++		TRACE("sBlk.uid_start 0x%llx\n", sBlk.uid_start);
++		TRACE("sBlk.guid_start 0x%llx\n", sBlk.guid_start);
++	}
++}
++
++
++int check_compression(struct compressor *comp)
++{
++	int res, bytes = 0;
++	char buffer[SQUASHFS_METADATA_SIZE] __attribute__ ((aligned));
++
++	if(!comp->supported) {
++		ERROR("Filesystem uses %s compression, this is "
++			"unsupported by this version\n", comp->name);
++		ERROR("Decompressors available:\n");
++		display_compressors("", "");
++		return 0;
++	}
++
++	/*
++	 * Read compression options from disk if present, and pass to
++	 * the compressor to ensure we know how to decompress a filesystem
++	 * compressed with these compression options.
++	 *
++	 * Note, even if there is no compression options we still call the
++	 * compressor because some compression options may be mandatory
++	 * for some compressors.
++	 */
++	if(SQUASHFS_COMP_OPTS(sBlk.s.flags)) {
++		bytes = read_block(fd, sizeof(sBlk.s), NULL, 0, buffer);
++		if(bytes == 0) {
++			ERROR("Failed to read compressor options\n");
++			return 0;
++		}
++	}
++
++	res = compressor_check_options(comp, sBlk.s.block_size, buffer, bytes);
++
++	return res != -1;
++}
++
++
++int read_super(char *source)
++{
++	squashfs_super_block_3 sBlk_3;
++	struct squashfs_super_block sBlk_4;
++
++	/*
++	 * Try to read a Squashfs 4 superblock
++	 */
++	read_fs_bytes(fd, SQUASHFS_START, sizeof(struct squashfs_super_block),
++		&sBlk_4);
++	swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
++	SQUASHFS_INSWAP_SUPER_BLOCK(&sBlk_4);
++
++	if(sBlk_4.s_magic == SQUASHFS_MAGIC && sBlk_4.s_major == 4 &&
++			sBlk_4.s_minor == 0) {
++		s_ops.squashfs_opendir = squashfs_opendir_4;
++		s_ops.read_fragment = read_fragment_4;
++		s_ops.read_fragment_table = read_fragment_table_4;
++		s_ops.read_block_list = read_block_list_2;
++		s_ops.read_inode = read_inode_4;
++		s_ops.read_uids_guids = read_uids_guids_4;
++		memcpy(&sBlk, &sBlk_4, sizeof(sBlk_4));
++
++		/*
++		 * Check the compression type
++		 */
++		comp = lookup_compressor_id(sBlk.s.compression);
++		return TRUE;
++	}
++
++	/*
++ 	 * Not a Squashfs 4 superblock, try to read a squashfs 3 superblock
++ 	 * (compatible with 1 and 2 filesystems)
++ 	 */
++	read_fs_bytes(fd, SQUASHFS_START, sizeof(squashfs_super_block_3),
++		&sBlk_3);
++
++	/*
++	 * Check it is a SQUASHFS superblock
++	 */
++	swap = 0;
++	if(sBlk_3.s_magic != SQUASHFS_MAGIC) {
++		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP) {
++			squashfs_super_block_3 sblk;
++			ERROR("Reading a different endian SQUASHFS filesystem "
++				"on %s\n", source);
++			SQUASHFS_SWAP_SUPER_BLOCK_3(&sblk, &sBlk_3);
++			memcpy(&sBlk_3, &sblk, sizeof(squashfs_super_block_3));
++			swap = 1;
++		} else  {
++			ERROR("Can't find a SQUASHFS superblock on %s\n",
++				source);
++			goto failed_mount;
++		}
++	}
++
++	sBlk.s.s_magic = sBlk_3.s_magic;
++	sBlk.s.inodes = sBlk_3.inodes;
++	sBlk.s.mkfs_time = sBlk_3.mkfs_time;
++	sBlk.s.block_size = sBlk_3.block_size;
++	sBlk.s.fragments = sBlk_3.fragments;
++	sBlk.s.block_log = sBlk_3.block_log;
++	sBlk.s.flags = sBlk_3.flags;
++	sBlk.s.s_major = sBlk_3.s_major;
++	sBlk.s.s_minor = sBlk_3.s_minor;
++	sBlk.s.root_inode = sBlk_3.root_inode;
++	sBlk.s.bytes_used = sBlk_3.bytes_used;
++	sBlk.s.inode_table_start = sBlk_3.inode_table_start;
++	sBlk.s.directory_table_start = sBlk_3.directory_table_start;
++	sBlk.s.fragment_table_start = sBlk_3.fragment_table_start;
++	sBlk.s.lookup_table_start = sBlk_3.lookup_table_start;
++	sBlk.no_uids = sBlk_3.no_uids;
++	sBlk.no_guids = sBlk_3.no_guids;
++	sBlk.uid_start = sBlk_3.uid_start;
++	sBlk.guid_start = sBlk_3.guid_start;
++	sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
++
++	/* Check the MAJOR & MINOR versions */
++	if(sBlk.s.s_major == 1 || sBlk.s.s_major == 2) {
++		sBlk.s.bytes_used = sBlk_3.bytes_used_2;
++		sBlk.uid_start = sBlk_3.uid_start_2;
++		sBlk.guid_start = sBlk_3.guid_start_2;
++		sBlk.s.inode_table_start = sBlk_3.inode_table_start_2;
++		sBlk.s.directory_table_start = sBlk_3.directory_table_start_2;
++		
++		if(sBlk.s.s_major == 1) {
++			sBlk.s.block_size = sBlk_3.block_size_1;
++			sBlk.s.fragment_table_start = sBlk.uid_start;
++			s_ops.squashfs_opendir = squashfs_opendir_1;
++			s_ops.read_fragment_table = read_fragment_table_1;
++			s_ops.read_block_list = read_block_list_1;
++			s_ops.read_inode = read_inode_1;
++			s_ops.read_uids_guids = read_uids_guids_1;
++		} else {
++			sBlk.s.fragment_table_start =
++				sBlk_3.fragment_table_start_2;
++			s_ops.squashfs_opendir = squashfs_opendir_1;
++			s_ops.read_fragment = read_fragment_2;
++			s_ops.read_fragment_table = read_fragment_table_2;
++			s_ops.read_block_list = read_block_list_2;
++			s_ops.read_inode = read_inode_2;
++			s_ops.read_uids_guids = read_uids_guids_1;
++		}
++	} else if(sBlk.s.s_major == 3) {
++		s_ops.squashfs_opendir = squashfs_opendir_3;
++		s_ops.read_fragment = read_fragment_3;
++		s_ops.read_fragment_table = read_fragment_table_3;
++		s_ops.read_block_list = read_block_list_2;
++		s_ops.read_inode = read_inode_3;
++		s_ops.read_uids_guids = read_uids_guids_1;
++	} else {
++		ERROR("Filesystem on %s is (%d:%d), ", source, sBlk.s.s_major,
++			sBlk.s.s_minor);
++		ERROR("which is a later filesystem version than I support!\n");
++		goto failed_mount;
++	}
++
++	/*
++	 * 1.x, 2.x and 3.x filesystems use gzip compression.
++	 */
++	comp = lookup_compressor("gzip");
++	return TRUE;
++
++failed_mount:
++	return FALSE;
++}
++
++
++struct pathname *process_extract_files(struct pathname *path, char *filename)
++{
++	FILE *fd;
++	char buffer[MAX_LINE + 1]; /* overflow safe */
++	char *name;
++
++	fd = fopen(filename, "r");
++	if(fd == NULL)
++		EXIT_UNSQUASH("Failed to open extract file \"%s\" because %s\n",
++			filename, strerror(errno));
++
++	while(fgets(name = buffer, MAX_LINE + 1, fd) != NULL) {
++		int len = strlen(name);
++
++		if(len == MAX_LINE && name[len - 1] != '\n')
++			/* line too large */
++			EXIT_UNSQUASH("Line too long when reading "
++				"extract file \"%s\", larger than %d "
++				"bytes\n", filename, MAX_LINE);
++
++		/*
++		 * Remove '\n' terminator if it exists (the last line
++		 * in the file may not be '\n' terminated)
++		 */
++		if(len && name[len - 1] == '\n')
++			name[len - 1] = '\0';
++
++		/* Skip any leading whitespace */
++		while(isspace(*name))
++			name ++;
++
++		/* if comment line, skip */
++		if(*name == '#')
++			continue;
++
++		/* check for initial backslash, to accommodate
++		 * filenames with leading space or leading # character
++		 */
++		if(*name == '\\')
++			name ++;
++
++		/* if line is now empty after skipping characters, skip it */
++		if(*name == '\0')
++			continue;
++
++		path = add_path(path, name, name);
++	}
++
++	if(ferror(fd))
++		EXIT_UNSQUASH("Reading extract file \"%s\" failed because %s\n",
++			filename, strerror(errno));
++
++	fclose(fd);
++	return path;
++}
++		
++
++/*
++ * reader thread.  This thread processes read requests queued by the
++ * cache_get() routine.
++ */
++void *reader(void *arg)
++{
++	while(1) {
++		struct cache_entry *entry = queue_get(to_reader);
++		int res = read_fs_bytes(fd, entry->block,
++			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size),
++			entry->data);
++
++		if(res && SQUASHFS_COMPRESSED_BLOCK(entry->size))
++			/*
++			 * queue successfully read block to the inflate
++			 * thread(s) for further processing
++ 			 */
++			queue_put(to_inflate, entry);
++		else
++			/*
++			 * block has either been successfully read and is
++			 * uncompressed, or an error has occurred, clear pending
++			 * flag, set error appropriately, and wake up any
++			 * threads waiting on this buffer
++			 */
++			cache_block_ready(entry, !res);
++	}
++}
++
++
++/*
++ * writer thread.  This processes file write requests queued by the
++ * write_file() routine.
++ */
++void *writer(void *arg)
++{
++	int i;
++
++	while(1) {
++		struct squashfs_file *file = queue_get(to_writer);
++		int file_fd;
++		long long hole = 0;
++		int failed = FALSE;
++		int error;
++
++		if(file == NULL) {
++			queue_put(from_writer, NULL);
++			continue;
++		} else if(file->fd == -1) {
++			/* write attributes for directory file->pathname */
++			set_attributes(file->pathname, file->mode, file->uid,
++				file->gid, file->time, file->xattr, TRUE);
++			free(file->pathname);
++			free(file);
++			continue;
++		}
++
++		TRACE("writer: regular file, blocks %d\n", file->blocks);
++
++		file_fd = file->fd;
++
++		for(i = 0; i < file->blocks; i++, cur_blocks ++) {
++			struct file_entry *block = queue_get(to_writer);
++
++			if(block->buffer == 0) { /* sparse file */
++				hole += block->size;
++				free(block);
++				continue;
++			}
++
++			cache_block_wait(block->buffer);
++
++			if(block->buffer->error)
++				failed = TRUE;
++
++			if(failed)
++				continue;
++
++			error = write_block(file_fd, block->buffer->data +
++				block->offset, block->size, hole, file->sparse);
++
++			if(error == FALSE) {
++				ERROR("writer: failed to write data block %d\n",
++					i);
++				failed = TRUE;
++			}
++
++			hole = 0;
++			cache_block_put(block->buffer);
++			free(block);
++		}
++
++		if(hole && failed == FALSE) {
++			/*
++			 * corner case for hole extending to end of file
++			 */
++			if(file->sparse == FALSE ||
++					lseek(file_fd, hole, SEEK_CUR) == -1) {
++				/*
++				 * for files which we don't want to write
++				 * sparsely, or for broken lseeks which cannot
++				 * seek beyond end of file, write_block will do
++				 * the right thing
++				 */
++				hole --;
++				if(write_block(file_fd, "\0", 1, hole,
++						file->sparse) == FALSE) {
++					ERROR("writer: failed to write sparse "
++						"data block\n");
++					failed = TRUE;
++				}
++			} else if(ftruncate(file_fd, file->file_size) == -1) {
++				ERROR("writer: failed to write sparse data "
++					"block\n");
++				failed = TRUE;
++			}
++		}
++
++		close_wake(file_fd);
++		if(failed == FALSE)
++			set_attributes(file->pathname, file->mode, file->uid,
++				file->gid, file->time, file->xattr, force);
++		else {
++			ERROR("Failed to write %s, skipping\n", file->pathname);
++			unlink(file->pathname);
++		}
++		free(file->pathname);
++		free(file);
++
++	}
++}
++
++
++/*
++ * decompress thread.  This decompresses buffers queued by the read thread
++ */
++void *inflator(void *arg)
++{
++	char tmp[block_size];
++
++	while(1) {
++		struct cache_entry *entry = queue_get(to_inflate);
++		int error, res;
++
++		res = compressor_uncompress(comp, tmp, entry->data,
++			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size), block_size,
++			&error);
++
++		if(res == -1)
++			ERROR("%s uncompress failed with error code %d\n",
++				comp->name, error);
++		else
++			memcpy(entry->data, tmp, res);
++
++		/*
++		 * block has been either successfully decompressed, or an error
++ 		 * occurred, clear pending flag, set error appropriately and
++ 		 * wake up any threads waiting on this block
++ 		 */ 
++		cache_block_ready(entry, res == -1);
++	}
++}
++
++
++void *progress_thread(void *arg)
++{
++	struct timespec requested_time, remaining;
++	struct itimerval itimerval;
++	struct winsize winsize;
++
++	if(ioctl(1, TIOCGWINSZ, &winsize) == -1) {
++		if(isatty(STDOUT_FILENO))
++			ERROR("TIOCGWINSZ ioctl failed, defaulting to 80 "
++				"columns\n");
++		columns = 80;
++	} else
++		columns = winsize.ws_col;
++	signal(SIGWINCH, sigwinch_handler);
++	signal(SIGALRM, sigalrm_handler);
++
++	itimerval.it_value.tv_sec = 0;
++	itimerval.it_value.tv_usec = 250000;
++	itimerval.it_interval.tv_sec = 0;
++	itimerval.it_interval.tv_usec = 250000;
++	setitimer(ITIMER_REAL, &itimerval, NULL);
++
++	requested_time.tv_sec = 0;
++	requested_time.tv_nsec = 250000000;
++
++	while(1) {
++		int res = nanosleep(&requested_time, &remaining);
++
++		if(res == -1 && errno != EINTR)
++			EXIT_UNSQUASH("nanosleep failed in progress thread\n");
++
++		if(progress_enabled) {
++			pthread_mutex_lock(&screen_mutex);
++			progress_bar(sym_count + dev_count +
++				fifo_count + cur_blocks, total_inodes -
++				total_files + total_blocks, columns);
++			pthread_mutex_unlock(&screen_mutex);
++		}
++	}
++}
++
++
++void initialise_threads(int fragment_buffer_size, int data_buffer_size)
++{
++	struct rlimit rlim;
++	int i, max_files, res;
++	sigset_t sigmask, old_mask;
++
++	/* block SIGQUIT and SIGHUP, these are handled by the info thread */
++	sigemptyset(&sigmask);
++	sigaddset(&sigmask, SIGQUIT);
++	sigaddset(&sigmask, SIGHUP);
++	if(pthread_sigmask(SIG_BLOCK, &sigmask, NULL) == -1)
++		EXIT_UNSQUASH("Failed to set signal mask in initialise_threads"
++			"\n");
++
++	/*
++	 * temporarily block these signals so the created sub-threads will
++	 * ignore them, ensuring the main thread handles them
++	 */
++	sigemptyset(&sigmask);
++	sigaddset(&sigmask, SIGINT);
++	sigaddset(&sigmask, SIGTERM);
++	if(pthread_sigmask(SIG_BLOCK, &sigmask, &old_mask) == -1)
++		EXIT_UNSQUASH("Failed to set signal mask in initialise_threads"
++			"\n");
++
++	if(processors == -1) {
++#ifndef linux
++		int mib[2];
++		size_t len = sizeof(processors);
++
++		mib[0] = CTL_HW;
++#ifdef HW_AVAILCPU
++		mib[1] = HW_AVAILCPU;
++#else
++		mib[1] = HW_NCPU;
++#endif
++
++		if(sysctl(mib, 2, &processors, &len, NULL, 0) == -1) {
++			ERROR("Failed to get number of available processors.  "
++				"Defaulting to 1\n");
++			processors = 1;
++		}
++#else
++		processors = sysconf(_SC_NPROCESSORS_ONLN);
++#endif
++	}
++
++	if(add_overflow(processors, 3) ||
++			multiply_overflow(processors + 3, sizeof(pthread_t)))
++		EXIT_UNSQUASH("Processors too large\n");
++
++	thread = malloc((3 + processors) * sizeof(pthread_t));
++	if(thread == NULL)
++		EXIT_UNSQUASH("Out of memory allocating thread descriptors\n");
++	inflator_thread = &thread[3];
++
++	/*
++	 * dimensioning the to_reader and to_inflate queues.  The size of
++	 * these queues is directly related to the amount of block
++	 * read-ahead possible.  To_reader queues block read requests to
++	 * the reader thread and to_inflate queues block decompression
++	 * requests to the inflate thread(s) (once the block has been read by
++	 * the reader thread).  The amount of read-ahead is determined by
++	 * the combined size of the data_block and fragment caches which
++	 * determine the total number of blocks which can be "in flight"
++	 * at any one time (either being read or being decompressed)
++	 *
++	 * The maximum file open limit, however, affects the read-ahead
++	 * possible, in that for normal sizes of the fragment and data block
++	 * caches, where the incoming files have few data blocks or one fragment
++	 * only, the file open limit is likely to be reached before the
++	 * caches are full.  This means the worst case sizing of the combined
++	 * sizes of the caches is unlikely to ever be necessary.  However, is is
++	 * obvious read-ahead up to the data block cache size is always possible
++	 * irrespective of the file open limit, because a single file could
++	 * contain that number of blocks.
++	 *
++	 * Choosing the size as "file open limit + data block cache size" seems
++	 * to be a reasonable estimate.  We can reasonably assume the maximum
++	 * likely read-ahead possible is data block cache size + one fragment
++	 * per open file.
++	 *
++	 * dimensioning the to_writer queue.  The size of this queue is
++	 * directly related to the amount of block read-ahead possible.
++	 * However, unlike the to_reader and to_inflate queues, this is
++	 * complicated by the fact the to_writer queue not only contains
++	 * entries for fragments and data_blocks but it also contains
++	 * file entries, one per open file in the read-ahead.
++	 *
++	 * Choosing the size as "2 * (file open limit) +
++	 * data block cache size" seems to be a reasonable estimate.
++	 * We can reasonably assume the maximum likely read-ahead possible
++	 * is data block cache size + one fragment per open file, and then
++	 * we will have a file_entry for each open file.
++	 */
++	res = getrlimit(RLIMIT_NOFILE, &rlim);
++	if (res == -1) {
++		ERROR("failed to get open file limit!  Defaulting to 1\n");
++		rlim.rlim_cur = 1;
++	}
++
++	if (rlim.rlim_cur != RLIM_INFINITY) {
++		/*
++		 * leave OPEN_FILE_MARGIN free (rlim_cur includes fds used by
++		 * stdin, stdout, stderr and filesystem fd
++		 */
++		if (rlim.rlim_cur <= OPEN_FILE_MARGIN)
++			/* no margin, use minimum possible */
++			max_files = 1;
++		else
++			max_files = rlim.rlim_cur - OPEN_FILE_MARGIN;
++	} else
++		max_files = -1;
++
++	/* set amount of available files for use by open_wait and close_wake */
++	open_init(max_files);
++
++	/*
++	 * allocate to_reader, to_inflate and to_writer queues.  Set based on
++	 * open file limit and cache size, unless open file limit is unlimited,
++	 * in which case set purely based on cache limits
++	 *
++	 * In doing so, check that the user supplied values do not overflow
++	 * a signed int
++	 */
++	if (max_files != -1) {
++		if(add_overflow(data_buffer_size, max_files) ||
++				add_overflow(data_buffer_size, max_files * 2))
++			EXIT_UNSQUASH("Data queue size is too large\n");
++
++		to_reader = queue_init(max_files + data_buffer_size);
++		to_inflate = queue_init(max_files + data_buffer_size);
++		to_writer = queue_init(max_files * 2 + data_buffer_size);
++	} else {
++		int all_buffers_size;
++
++		if(add_overflow(fragment_buffer_size, data_buffer_size))
++			EXIT_UNSQUASH("Data and fragment queues combined are"
++							" too large\n");
++
++		all_buffers_size = fragment_buffer_size + data_buffer_size;
++
++		if(add_overflow(all_buffers_size, all_buffers_size))
++			EXIT_UNSQUASH("Data and fragment queues combined are"
++							" too large\n");
++
++		to_reader = queue_init(all_buffers_size);
++		to_inflate = queue_init(all_buffers_size);
++		to_writer = queue_init(all_buffers_size * 2);
++	}
++
++	from_writer = queue_init(1);
++
++	fragment_cache = cache_init(block_size, fragment_buffer_size);
++	data_cache = cache_init(block_size, data_buffer_size);
++	pthread_create(&thread[0], NULL, reader, NULL);
++	pthread_create(&thread[1], NULL, writer, NULL);
++	pthread_create(&thread[2], NULL, progress_thread, NULL);
++	init_info();
++	pthread_mutex_init(&fragment_mutex, NULL);
++
++	for(i = 0; i < processors; i++) {
++		if(pthread_create(&inflator_thread[i], NULL, inflator, NULL) !=
++				 0)
++			EXIT_UNSQUASH("Failed to create thread\n");
++	}
++
++	printf("Parallel unsquashfs: Using %d processor%s\n", processors,
++			processors == 1 ? "" : "s");
++
++	if(pthread_sigmask(SIG_SETMASK, &old_mask, NULL) == -1)
++		EXIT_UNSQUASH("Failed to set signal mask in initialise_threads"
++			"\n");
++}
++
++
++void enable_progress_bar()
++{
++	pthread_mutex_lock(&screen_mutex);
++	progress_enabled = progress;
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++
++void disable_progress_bar()
++{
++	pthread_mutex_lock(&screen_mutex);
++	if(progress_enabled) {
++		progress_bar(sym_count + dev_count + fifo_count + cur_blocks,
++			total_inodes - total_files + total_blocks, columns);
++		printf("\n");
++	}
++	progress_enabled = FALSE;
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++
++void progressbar_error(char *fmt, ...)
++{
++	va_list ap;
++
++	pthread_mutex_lock(&screen_mutex);
++
++	if(progress_enabled)
++		fprintf(stderr, "\n");
++
++	va_start(ap, fmt);
++	vfprintf(stderr, fmt, ap);
++	va_end(ap);
++
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++
++void progressbar_info(char *fmt, ...)
++{
++	va_list ap;
++
++	pthread_mutex_lock(&screen_mutex);
++
++	if(progress_enabled)
++		printf("\n");
++
++	va_start(ap, fmt);
++	vprintf(fmt, ap);
++	va_end(ap);
++
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++void progress_bar(long long current, long long max, int columns)
++{
++	char rotate_list[] = { '|', '/', '-', '\\' };
++	int max_digits, used, hashes, spaces;
++	static int tty = -1;
++
++	if(max == 0)
++		return;
++
++	max_digits = floor(log10(max)) + 1;
++	used = max_digits * 2 + 11;
++	hashes = (current * (columns - used)) / max;
++	spaces = columns - used - hashes;
++
++	if((current > max) || (columns - used < 0))
++		return;
++
++	if(tty == -1)
++		tty = isatty(STDOUT_FILENO);
++	if(!tty) {
++		static long long previous = -1;
++
++		/*
++		 * Updating much more frequently than this results in huge
++		 * log files.
++		 */
++		if((current % 100) != 0 && current != max)
++			return;
++		/* Don't update just to rotate the spinner. */
++		if(current == previous)
++			return;
++		previous = current;
++	}
++
++	printf("\r[");
++
++	while (hashes --)
++		putchar('=');
++
++	putchar(rotate_list[rotate]);
++
++	while(spaces --)
++		putchar(' ');
++
++	printf("] %*lld/%*lld", max_digits, current, max_digits, max);
++	printf(" %3lld%%", current * 100 / max);
++	fflush(stdout);
++}
++
++
++int parse_number(char *arg, int *res)
++{
++	char *b;
++	long number = strtol(arg, &b, 10);
++
++	/* check for trailing junk after number */
++	if(*b != '\0')
++		return 0;
++
++	/*
++	 * check for strtol underflow or overflow in conversion.
++	 * Note: strtol can validly return LONG_MIN and LONG_MAX
++	 * if the user entered these values, but, additional code
++	 * to distinguish this scenario is unnecessary, because for
++	 * our purposes LONG_MIN and LONG_MAX are too large anyway
++	 */
++	if(number == LONG_MIN || number == LONG_MAX)
++		return 0;
++
++	/* reject negative numbers as invalid */
++	if(number < 0)
++		return 0;
++
++	/* check if long result will overflow signed int */
++	if(number > INT_MAX)
++		return 0;
++
++	*res = number;
++	return 1;
++}
++
++
++#define VERSION() \
++	printf("unsquashfs version 4.3 (2014/05/12)\n");\
++	printf("copyright (C) 2014 Phillip Lougher "\
++		"<phillip@squashfs.org.uk>\n\n");\
++    	printf("This program is free software; you can redistribute it and/or"\
++		"\n");\
++	printf("modify it under the terms of the GNU General Public License"\
++		"\n");\
++	printf("as published by the Free Software Foundation; either version "\
++		"2,\n");\
++	printf("or (at your option) any later version.\n\n");\
++	printf("This program is distributed in the hope that it will be "\
++		"useful,\n");\
++	printf("but WITHOUT ANY WARRANTY; without even the implied warranty of"\
++		"\n");\
++	printf("MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the"\
++		"\n");\
++	printf("GNU General Public License for more details.\n");
++int main(int argc, char *argv[])
++{
++	char *dest = "squashfs-root";
++	int i, stat_sys = FALSE, version = FALSE;
++	int n;
++	struct pathnames *paths = NULL;
++	struct pathname *path = NULL;
++	long long directory_table_end;
++	int fragment_buffer_size = FRAGMENT_BUFFER_DEFAULT;
++	int data_buffer_size = DATA_BUFFER_DEFAULT;
++
++	pthread_mutex_init(&screen_mutex, NULL);
++	root_process = geteuid() == 0;
++	if(root_process)
++		umask(0);
++	
++	for(i = 1; i < argc; i++) {
++		if(*argv[i] != '-')
++			break;
++		if(strcmp(argv[i], "-version") == 0 ||
++				strcmp(argv[i], "-v") == 0) {
++			VERSION();
++			version = TRUE;
++		} else if(strcmp(argv[i], "-info") == 0 ||
++				strcmp(argv[i], "-i") == 0)
++			info = TRUE;
++		else if(strcmp(argv[i], "-ls") == 0 ||
++				strcmp(argv[i], "-l") == 0)
++			lsonly = TRUE;
++		else if(strcmp(argv[i], "-no-progress") == 0 ||
++				strcmp(argv[i], "-n") == 0)
++			progress = FALSE;
++		else if(strcmp(argv[i], "-no-xattrs") == 0 ||
++				strcmp(argv[i], "-no") == 0)
++			no_xattrs = TRUE;
++		else if(strcmp(argv[i], "-xattrs") == 0 ||
++				strcmp(argv[i], "-x") == 0)
++			no_xattrs = FALSE;
++		else if(strcmp(argv[i], "-user-xattrs") == 0 ||
++				strcmp(argv[i], "-u") == 0) {
++			user_xattrs = TRUE;
++			no_xattrs = FALSE;
++		} else if(strcmp(argv[i], "-dest") == 0 ||
++				strcmp(argv[i], "-d") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -dest missing filename\n",
++					argv[0]);
++				exit(1);
++			}
++			dest = argv[i];
++		} else if(strcmp(argv[i], "-processors") == 0 ||
++				strcmp(argv[i], "-p") == 0) {
++			if((++i == argc) || 
++					!parse_number(argv[i],
++						&processors)) {
++				ERROR("%s: -processors missing or invalid "
++					"processor number\n", argv[0]);
++				exit(1);
++			}
++			if(processors < 1) {
++				ERROR("%s: -processors should be 1 or larger\n",
++					argv[0]);
++				exit(1);
++			}
++		} else if(strcmp(argv[i], "-data-queue") == 0 ||
++					 strcmp(argv[i], "-da") == 0) {
++			if((++i == argc) ||
++					!parse_number(argv[i],
++						&data_buffer_size)) {
++				ERROR("%s: -data-queue missing or invalid "
++					"queue size\n", argv[0]);
++				exit(1);
++			}
++			if(data_buffer_size < 1) {
++				ERROR("%s: -data-queue should be 1 Mbyte or "
++					"larger\n", argv[0]);
++				exit(1);
++			}
++		} else if(strcmp(argv[i], "-frag-queue") == 0 ||
++					strcmp(argv[i], "-fr") == 0) {
++			if((++i == argc) ||
++					!parse_number(argv[i],
++						&fragment_buffer_size)) {
++				ERROR("%s: -frag-queue missing or invalid "
++					"queue size\n", argv[0]);
++				exit(1);
++			}
++			if(fragment_buffer_size < 1) {
++				ERROR("%s: -frag-queue should be 1 Mbyte or "
++					"larger\n", argv[0]);
++				exit(1);
++			}
++		} else if(strcmp(argv[i], "-force") == 0 ||
++				strcmp(argv[i], "-f") == 0)
++			force = TRUE;
++		else if(strcmp(argv[i], "-stat") == 0 ||
++				strcmp(argv[i], "-s") == 0)
++			stat_sys = TRUE;
++		else if(strcmp(argv[i], "-lls") == 0 ||
++				strcmp(argv[i], "-ll") == 0) {
++			lsonly = TRUE;
++			short_ls = FALSE;
++		} else if(strcmp(argv[i], "-linfo") == 0 ||
++				strcmp(argv[i], "-li") == 0) {
++			info = TRUE;
++			short_ls = FALSE;
++		} else if(strcmp(argv[i], "-ef") == 0 ||
++				strcmp(argv[i], "-e") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -ef missing filename\n",
++					argv[0]);
++				exit(1);
++			}
++			path = process_extract_files(path, argv[i]);
++		} else if(strcmp(argv[i], "-regex") == 0 ||
++				strcmp(argv[i], "-r") == 0)
++			use_regex = TRUE;
++		else
++			goto options;
++	}
++
++	if(lsonly || info)
++		progress = FALSE;
++
++#ifdef SQUASHFS_TRACE
++	/*
++	 * Disable progress bar if full debug tracing is enabled.
++	 * The progress bar in this case just gets in the way of the
++	 * debug trace output
++	 */
++	progress = FALSE;
++#endif
++
++	if(i == argc) {
++		if(!version) {
++options:
++			ERROR("SYNTAX: %s [options] filesystem [directories or "
++				"files to extract]\n", argv[0]);
++			ERROR("\t-v[ersion]\t\tprint version, licence and "
++				"copyright information\n");
++			ERROR("\t-d[est] <pathname>\tunsquash to <pathname>, "
++				"default \"squashfs-root\"\n");
++			ERROR("\t-n[o-progress]\t\tdon't display the progress "
++				"bar\n");
++			ERROR("\t-no[-xattrs]\t\tdon't extract xattrs in file system"
++				NOXOPT_STR"\n");
++			ERROR("\t-x[attrs]\t\textract xattrs in file system"
++				XOPT_STR "\n");
++			ERROR("\t-u[ser-xattrs]\t\tonly extract user xattrs in "
++				"file system.\n\t\t\t\tEnables extracting "
++				"xattrs\n");
++			ERROR("\t-p[rocessors] <number>\tuse <number> "
++				"processors.  By default will use\n");
++			ERROR("\t\t\t\tnumber of processors available\n");
++			ERROR("\t-i[nfo]\t\t\tprint files as they are "
++				"unsquashed\n");
++			ERROR("\t-li[nfo]\t\tprint files as they are "
++				"unsquashed with file\n");
++			ERROR("\t\t\t\tattributes (like ls -l output)\n");
++			ERROR("\t-l[s]\t\t\tlist filesystem, but don't unsquash"
++				"\n");
++			ERROR("\t-ll[s]\t\t\tlist filesystem with file "
++				"attributes (like\n");
++			ERROR("\t\t\t\tls -l output), but don't unsquash\n");
++			ERROR("\t-f[orce]\t\tif file already exists then "
++				"overwrite\n");
++			ERROR("\t-s[tat]\t\t\tdisplay filesystem superblock "
++				"information\n");
++			ERROR("\t-e[f] <extract file>\tlist of directories or "
++				"files to extract.\n\t\t\t\tOne per line\n");
++			ERROR("\t-da[ta-queue] <size>\tSet data queue to "
++				"<size> Mbytes.  Default %d\n\t\t\t\tMbytes\n",
++				DATA_BUFFER_DEFAULT);
++			ERROR("\t-fr[ag-queue] <size>\tSet fragment queue to "
++				"<size> Mbytes.  Default\n\t\t\t\t%d Mbytes\n",
++				FRAGMENT_BUFFER_DEFAULT);
++			ERROR("\t-r[egex]\t\ttreat extract names as POSIX "
++				"regular expressions\n");
++			ERROR("\t\t\t\trather than use the default shell "
++				"wildcard\n\t\t\t\texpansion (globbing)\n");
++			ERROR("\nDecompressors available:\n");
++			display_compressors("", "");
++		}
++		exit(1);
++	}
++
++	for(n = i + 1; n < argc; n++)
++		path = add_path(path, argv[n], argv[n]);
++
++	if((fd = open(argv[i], O_RDONLY)) == -1) {
++		ERROR("Could not open %s, because %s\n", argv[i],
++			strerror(errno));
++		exit(1);
++	}
++
++	if(read_super(argv[i]) == FALSE)
++		exit(1);
++
++	if(stat_sys) {
++		squashfs_stat(argv[i]);
++		exit(0);
++	}
++
++	if(!check_compression(comp))
++		exit(1);
++
++	block_size = sBlk.s.block_size;
++	block_log = sBlk.s.block_log;
++
++	/*
++	 * Sanity check block size and block log.
++	 *
++	 * Check they're within correct limits
++	 */
++	if(block_size > SQUASHFS_FILE_MAX_SIZE ||
++					block_log > SQUASHFS_FILE_MAX_LOG)
++		EXIT_UNSQUASH("Block size or block_log too large."
++			"  File system is corrupt.\n");
++
++	/*
++	 * Check block_size and block_log match
++	 */
++	if(block_size != (1 << block_log))
++		EXIT_UNSQUASH("Block size and block_log do not match."
++			"  File system is corrupt.\n");
++
++	/*
++	 * convert from queue size in Mbytes to queue size in
++	 * blocks.
++	 *
++	 * In doing so, check that the user supplied values do not
++	 * overflow a signed int
++	 */
++	if(shift_overflow(fragment_buffer_size, 20 - block_log))
++		EXIT_UNSQUASH("Fragment queue size is too large\n");
++	else
++		fragment_buffer_size <<= 20 - block_log;
++
++	if(shift_overflow(data_buffer_size, 20 - block_log))
++		EXIT_UNSQUASH("Data queue size is too large\n");
++	else
++		data_buffer_size <<= 20 - block_log;
++
++	initialise_threads(fragment_buffer_size, data_buffer_size);
++
++	fragment_data = malloc(block_size);
++	if(fragment_data == NULL)
++		EXIT_UNSQUASH("failed to allocate fragment_data\n");
++
++	file_data = malloc(block_size);
++	if(file_data == NULL)
++		EXIT_UNSQUASH("failed to allocate file_data");
++
++	data = malloc(block_size);
++	if(data == NULL)
++		EXIT_UNSQUASH("failed to allocate data\n");
++
++	created_inode = malloc(sBlk.s.inodes * sizeof(char *));
++	if(created_inode == NULL)
++		EXIT_UNSQUASH("failed to allocate created_inode\n");
++
++	memset(created_inode, 0, sBlk.s.inodes * sizeof(char *));
++
++	if(s_ops.read_uids_guids() == FALSE)
++		EXIT_UNSQUASH("failed to uid/gid table\n");
++
++	if(s_ops.read_fragment_table(&directory_table_end) == FALSE)
++		EXIT_UNSQUASH("failed to read fragment table\n");
++
++	if(read_inode_table(sBlk.s.inode_table_start,
++				sBlk.s.directory_table_start) == FALSE)
++		EXIT_UNSQUASH("failed to read inode table\n");
++
++	if(read_directory_table(sBlk.s.directory_table_start,
++				directory_table_end) == FALSE)
++		EXIT_UNSQUASH("failed to read directory table\n");
++
++	if(no_xattrs)
++		sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
++
++	if(read_xattrs_from_disk(fd, &sBlk.s) == 0)
++		EXIT_UNSQUASH("failed to read the xattr table\n");
++
++	if(path) {
++		paths = init_subdir();
++		paths = add_subdir(paths, path);
++	}
++
++	pre_scan(dest, SQUASHFS_INODE_BLK(sBlk.s.root_inode),
++		SQUASHFS_INODE_OFFSET(sBlk.s.root_inode), paths);
++
++	memset(created_inode, 0, sBlk.s.inodes * sizeof(char *));
++	inode_number = 1;
++
++	printf("%d inodes (%d blocks) to write\n\n", total_inodes,
++		total_inodes - total_files + total_blocks);
++
++	enable_progress_bar();
++
++	dir_scan(dest, SQUASHFS_INODE_BLK(sBlk.s.root_inode),
++		SQUASHFS_INODE_OFFSET(sBlk.s.root_inode), paths);
++
++	queue_put(to_writer, NULL);
++	queue_get(from_writer);
++
++	disable_progress_bar();
++
++	if(!lsonly) {
++		printf("\n");
++		printf("created %d files\n", file_count);
++		printf("created %d directories\n", dir_count);
++		printf("created %d symlinks\n", sym_count);
++		printf("created %d devices\n", dev_count);
++		printf("created %d fifos\n", fifo_count);
++	}
++
++	return 0;
++}


### PR DESCRIPTION
This makes gcc 11.2.0 on Ubuntu 22.04 to fail the build as a result of multiple definitions of this variable.
We now define it once in unsquashfs.c and extern it in error.h header file.